### PR TITLE
Harden optional auth JWT verification and stabilize proxy-related tests

### DIFF
--- a/__tests__/optionalAuth.test.js
+++ b/__tests__/optionalAuth.test.js
@@ -1,0 +1,47 @@
+const jwt = require('jsonwebtoken');
+const optionalAuthMiddleware = require('../src/middleware/optionalAuth');
+
+describe('optionalAuthMiddleware', () => {
+  const originalSecret = process.env.JWT_SECRET;
+
+  afterEach(() => {
+    process.env.JWT_SECRET = originalSecret;
+  });
+
+  it('does not authenticate tokens when JWT_SECRET is missing', async () => {
+    delete process.env.JWT_SECRET;
+
+    const req = {
+      headers: {
+        authorization: `Bearer ${jwt.sign({ id: 123 }, 'your-secret-key-change-this-in-production')}`
+      }
+    };
+
+    const res = {};
+    const next = jest.fn();
+
+    await optionalAuthMiddleware(req, res, next);
+
+    expect(req.user).toBeUndefined();
+    expect(next).toHaveBeenCalledTimes(1);
+  });
+
+  it('authenticates valid tokens when JWT_SECRET is configured', async () => {
+    process.env.JWT_SECRET = 'test-optional-auth-secret';
+
+    const req = {
+      headers: {
+        authorization: `Bearer ${jwt.sign({ id: 456 }, process.env.JWT_SECRET)}`
+      }
+    };
+
+    const res = {};
+    const next = jest.fn();
+
+    await optionalAuthMiddleware(req, res, next);
+
+    expect(req.user).toBeDefined();
+    expect(req.user.id).toBe(456);
+    expect(next).toHaveBeenCalledTimes(1);
+  });
+});

--- a/__tests__/polls.test.js
+++ b/__tests__/polls.test.js
@@ -14,7 +14,7 @@ const pollRoutes = require('../src/routes/pollRoutes');
 
 // Create test app
 const app = express();
-app.set('trust proxy', true);
+app.set('trust proxy', 1);
 app.use(helmet(helmetConfig));
 app.use(cors(corsOptions));
 app.use(express.json());

--- a/src/middleware/optionalAuth.js
+++ b/src/middleware/optionalAuth.js
@@ -11,12 +11,13 @@ const optionalAuthMiddleware = async (req, res, next) => {
     const token = bearerToken || cookieToken;
     
     if (token) {
-      // Ensure JWT_SECRET is set in production
-      if (!process.env.JWT_SECRET && process.env.NODE_ENV === 'production') {
-        throw new Error('JWT_SECRET must be set in production environment');
+      // Never use a fallback secret for verification.
+      // If JWT_SECRET is missing, continue as anonymous user.
+      if (!process.env.JWT_SECRET) {
+        return next();
       }
 
-      const decoded = jwt.verify(token, process.env.JWT_SECRET || 'your-secret-key-change-this-in-production');
+      const decoded = jwt.verify(token, process.env.JWT_SECRET);
       req.user = decoded;
     }
     // If no token, req.user remains undefined - this is expected


### PR DESCRIPTION
### Motivation
- Prevent token forgery by removing a known fallback JWT secret and ensuring verification only occurs when an explicit `JWT_SECRET` is configured.
- Make test app behavior match secure runtime expectations for proxy handling to avoid permissive trust-proxy settings in tests.
- Provide deterministic coverage for the new behavior with focused unit tests for optional authentication.

### Description
- Updated `src/middleware/optionalAuth.js` to stop using a fallback secret and to early-return (treat as anonymous) when `process.env.JWT_SECRET` is not set, and to call `jwt.verify` only with the real `JWT_SECRET`.
- Added unit tests in `__tests__/optionalAuth.test.js` that assert tokens are ignored when `JWT_SECRET` is missing and accepted when `JWT_SECRET` is configured.
- Changed `__tests__/polls.test.js` test app setup to use `app.set('trust proxy', 1)` instead of `true` to avoid trusting all proxies in tests.

### Testing
- Ran targeted test suites with `npm test -- __tests__/optionalAuth.test.js __tests__/security.test.js __tests__/polls.test.js --runInBand` and all selected suites passed.
- Test summary: `Test Suites: 3 passed, 3 total` and `Tests: 52 passed, 52 total`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69918dbc4c64832194701fc608c04ec8)