### PR TITLE
Improve static page UX and reorganize footer menu links

### DIFF
--- a/components/Footer.js
+++ b/components/Footer.js
@@ -2,9 +2,40 @@ import Link from 'next/link';
 
 export default function Footer() {
   const currentYear = new Date().getFullYear();
+  const footerColumns = [
+    {
+      title: 'Περιεχόμενο',
+      links: [
+        { href: '/news', label: 'Ειδήσεις' },
+        { href: '/articles', label: 'Άρθρα' },
+        { href: '/polls', label: 'Δημοσκοπήσεις' },
+        { href: '/locations', label: 'Τοποθεσίες' },
+      ],
+    },
+    {
+      title: 'Βοήθεια',
+      links: [
+        { href: '/faq', label: 'Συχνές Ερωτήσεις' },
+        { href: '/instructions', label: 'Οδηγίες Χρήσης' },
+        { href: '/rules', label: 'Κανόνες' },
+        { href: '/contribute', label: 'Συνεισφορά' },
+        { href: '/become-moderator', label: 'Γίνε Moderator' },
+      ],
+    },
+    {
+      title: 'Πληροφορίες',
+      links: [
+        { href: '/about', label: 'Σχετικά με εμάς' },
+        { href: '/mission', label: 'Αποστολή' },
+        { href: '/transparency', label: 'Διαφάνεια' },
+        { href: '/privacy', label: 'Πολιτική Απορρήτου' },
+        { href: '/terms', label: 'Όροι Χρήσης' },
+      ],
+    },
+  ];
 
   return (
-    <footer className="bg-gray-800 text-white mt-auto">
+    <footer className="bg-gray-800 text-white mt-auto" aria-label="Footer menu">
       <div className="app-container py-4">
         <div className="grid grid-cols-1 md:grid-cols-4 gap-4">
           {/* Column 1: About */}
@@ -15,69 +46,20 @@ export default function Footer() {
             </p>
           </div>
 
-          {/* Column 2: Content & Static Pages */}
-          <div>
-            <h3 className="text-lg font-semibold mb-4">Περιεχόμενο</h3>
-            <ul className="space-y-2">
-              <li>
-                <Link href="/news" className="text-gray-400 hover:text-white transition-colors text-sm">
-                  Ειδήσεις
-                </Link>
-              </li>
-              <li>
-                <Link href="/articles" className="text-gray-400 hover:text-white transition-colors text-sm">
-                  Άρθρα
-                </Link>
-              </li>
-              <li>
-                <Link href="/polls" className="text-gray-400 hover:text-white transition-colors text-sm">
-                  Δημοσκοπήσεις
-                </Link>
-              </li>
-              <li>
-                <Link href="/faq" className="text-gray-400 hover:text-white transition-colors text-sm">
-                  Συχνές Ερωτήσεις
-                </Link>
-              </li>
-              <li>
-                <Link href="/contribute" className="text-gray-400 hover:text-white transition-colors text-sm">
-                  Συνεισφορά
-                </Link>
-              </li>
-              <li>
-                <Link href="/become-moderator" className="text-gray-400 hover:text-white transition-colors text-sm">
-                  Γίνε Moderator
-                </Link>
-              </li>
-            </ul>
-          </div>
-
-          {/* Column 3: Πληροφορίες & Πολιτικές */}
-          <div>
-            <h3 className="text-lg font-semibold mb-4">Πληροφορίες</h3>
-            <ul className="space-y-2">
-              <li>
-                <Link href="/instructions" className="text-gray-400 hover:text-white transition-colors text-sm">
-                  Οδηγίες Χρήσης
-                </Link>
-              </li>
-              <li>
-                <Link href="/rules" className="text-gray-400 hover:text-white transition-colors text-sm">
-                  Κανόνες
-                </Link>
-              </li>
-              <li>
-                <Link href="/privacy" className="text-gray-400 hover:text-white transition-colors text-sm">
-                  Πολιτική Απορρήτου
-                </Link>
-              </li>
-              <li>
-                <Link href="/terms" className="text-gray-400 hover:text-white transition-colors text-sm">
-                  Όροι Χρήσης
-                </Link>
-              </li>
-            </ul>
-          </div>
+          {footerColumns.map((column) => (
+            <div key={column.title}>
+              <h3 className="text-lg font-semibold mb-4">{column.title}</h3>
+              <ul className="space-y-2">
+                {column.links.map((link) => (
+                  <li key={link.href}>
+                    <Link href={link.href} className="text-gray-400 hover:text-white transition-colors text-sm">
+                      {link.label}
+                    </Link>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          ))}
 
           {/* Column 4: Contact */}
           <div>
@@ -101,16 +83,6 @@ export default function Footer() {
               <li>
                 <Link href="/about" className="text-gray-400 hover:text-white transition-colors text-sm">
                   Σχετικά με εμάς
-                </Link>
-              </li>
-              <li>
-                <Link href="/transparency" className="text-gray-400 hover:text-white transition-colors text-sm">
-                  Διαφάνεια
-                </Link>
-              </li>
-              <li>
-                <Link href="/mission" className="text-gray-400 hover:text-white transition-colors text-sm">
-                  Αποστολή
                 </Link>
               </li>
             </ul>

--- a/components/StaticPageLayout.js
+++ b/components/StaticPageLayout.js
@@ -1,5 +1,7 @@
 'use client';
 
+import Link from 'next/link';
+
 /**
  * Reusable layout component for static content pages
  * Provides consistent structure for mission, instructions, contribute, etc.
@@ -9,13 +11,22 @@
  * @param {React.ReactNode} props.children - Page content
  * @param {string} props.maxWidth - Max width class (default: 'max-w-4xl')
  * @param {string} props.className - Additional CSS classes for the card element (optional)
+ * @param {boolean} props.showHelpfulLinks - Show helper links section (default: true)
  */
 export default function StaticPageLayout({ 
   title, 
   children, 
   maxWidth = 'max-w-4xl',
-  className = ''
+  className = '',
+  showHelpfulLinks = true
 }) {
+  const helpfulLinks = [
+    { href: '/faq', label: 'Συχνές Ερωτήσεις' },
+    { href: '/instructions', label: 'Οδηγίες Χρήσης' },
+    { href: '/rules', label: 'Κανόνες Κοινότητας' },
+    { href: '/contact', label: 'Επικοινωνία' },
+  ];
+
   return (
     <div className="bg-gray-50 min-h-screen py-8">
       <div className="app-container">
@@ -25,6 +36,23 @@ export default function StaticPageLayout({
         <div className={`card p-8 ${className}`}>
           <div className={`${maxWidth} space-y-12 mx-auto`}>
             {children}
+
+            {showHelpfulLinks && (
+              <section className="border-t border-gray-200 pt-8" aria-label="Χρήσιμοι σύνδεσμοι">
+                <h2 className="text-xl font-semibold mb-4">Χρήσιμοι σύνδεσμοι</h2>
+                <div className="flex flex-wrap gap-3">
+                  {helpfulLinks.map((link) => (
+                    <Link
+                      key={link.href}
+                      href={link.href}
+                      className="px-4 py-2 text-sm rounded-md bg-white border border-gray-200 text-gray-700 hover:text-blue-700 hover:border-blue-300 transition-colors"
+                    >
+                      {link.label}
+                    </Link>
+                  ))}
+                </div>
+              </section>
+            )}
           </div>
         </div>
       </div>


### PR DESCRIPTION
### Motivation
- Make static content easier to navigate by surfacing high-value links directly on static pages.
- Improve footer discoverability and maintainability by moving to a data-driven link structure.
- Add small accessibility and content updates to help users find locations, help pages and policies quickly.

### Description
- Refactored `components/Footer.js` to render footer columns from a `footerColumns` data structure and added an explicit `aria-label` for the footer container.
- Added a direct `Τοποθεσίες` (`/locations`) link and reorganized links into `Περιεχόμενο`, `Βοήθεια`, and `Πληροφορίες` groups for clearer hierarchy.
- Extended `components/StaticPageLayout.js` with a reusable "Χρήσιμοι σύνδεσμοι" section, imported `Link` and implemented a `helpfulLinks` array.
- Added a configurable `showHelpfulLinks` prop (default `true`) to allow pages to opt out of the helper links when needed.

### Testing
- Ran `npm run frontend:build` (Next.js production build) which completed successfully and generated static pages.
- Started the dev frontend with `npm run frontend` and the app served successfully (Next.js ready).
- Executed a Playwright script to capture a screenshot of `/about` which completed and produced `artifacts/static-footer-improvements.png`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69919d80ab4c8321801cd3e68e0ef378)