### PR TITLE
Admin: Add message detail page and improve AdminTable robustness and interactivity

### DIFF
--- a/app/admin/messages/[id]/page.js
+++ b/app/admin/messages/[id]/page.js
@@ -1,0 +1,110 @@
+'use client';
+
+import Link from 'next/link';
+import { useParams } from 'next/navigation';
+import ProtectedRoute from '@/components/ProtectedRoute';
+import Card from '@/components/Card';
+import { useAsyncData } from '@/hooks/useAsyncData';
+import { messageAPI } from '@/lib/api';
+
+function MessageDetailContent() {
+  const params = useParams();
+  const messageId = params?.id;
+
+  const { data: message, loading, error } = useAsyncData(
+    async () => {
+      if (!messageId) return null;
+      const response = await messageAPI.getById(messageId);
+      if (response.success) {
+        return response.data?.message || null;
+      }
+      return null;
+    },
+    [messageId],
+    { initialData: null }
+  );
+
+  return (
+    <div className="bg-gray-50 min-h-screen py-8">
+      <div className="app-container max-w-4xl mx-auto px-4 sm:px-6 lg:px-8">
+        <div className="mb-6">
+          <Link href="/admin/messages" className="text-sm text-blue-600 hover:text-blue-800 font-medium">
+            ← Επιστροφή στα μηνύματα
+          </Link>
+          <h1 className="text-3xl font-bold mt-2">Λεπτομέρειες Μηνύματος</h1>
+        </div>
+
+        {loading && (
+          <Card>
+            <p className="text-gray-500">Φόρτωση...</p>
+          </Card>
+        )}
+
+        {error && (
+          <Card>
+            <p className="text-red-600">Αποτυχία φόρτωσης μηνύματος.</p>
+          </Card>
+        )}
+
+        {!loading && !error && !message && (
+          <Card>
+            <p className="text-gray-600">Το μήνυμα δεν βρέθηκε.</p>
+          </Card>
+        )}
+
+        {!loading && !error && message && (
+          <Card>
+            <div className="space-y-4">
+              <div>
+                <h2 className="text-xl font-semibold text-gray-900">{message.subject}</h2>
+                <p className="text-sm text-gray-500 mt-1">
+                  {new Date(message.createdAt).toLocaleDateString('el-GR', {
+                    day: 'numeric',
+                    month: 'long',
+                    year: 'numeric',
+                    hour: '2-digit',
+                    minute: '2-digit'
+                  })}
+                </p>
+              </div>
+
+              <div className="border-t pt-4">
+                <h3 className="text-sm font-semibold text-gray-700 mb-1">Αποστολέας</h3>
+                <p className="text-gray-900">
+                  {message.user ? `${message.user.username} (${message.user.email})` : `${message.name} (${message.email})`}
+                </p>
+              </div>
+
+              <div className="border-t pt-4">
+                <h3 className="text-sm font-semibold text-gray-700 mb-1">Μήνυμα</h3>
+                <p className="text-gray-900 whitespace-pre-wrap">{message.message}</p>
+              </div>
+
+              {message.adminNotes && (
+                <div className="border-t pt-4">
+                  <h3 className="text-sm font-semibold text-gray-700 mb-1">Admin Notes</h3>
+                  <p className="text-gray-900 whitespace-pre-wrap">{message.adminNotes}</p>
+                </div>
+              )}
+
+              {message.response && (
+                <div className="border-t pt-4">
+                  <h3 className="text-sm font-semibold text-green-700 mb-1">Απάντηση</h3>
+                  <p className="text-gray-900 whitespace-pre-wrap">{message.response}</p>
+                </div>
+              )}
+            </div>
+          </Card>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export default function AdminMessageDetailPage() {
+  return (
+    <ProtectedRoute allowedRoles={['admin', 'moderator']}>
+      <MessageDetailContent />
+    </ProtectedRoute>
+  );
+}

--- a/app/admin/reports/page.js
+++ b/app/admin/reports/page.js
@@ -135,7 +135,7 @@ function ReportsContent() {
         );
       }
     },
-    { key: 'category', label: 'Category', render: (row) => row.category.replace(/_/g, ' ') },
+    { key: 'category', label: 'Category', render: (row) => row.category?.replace(/_/g, ' ') || '-' },
     {
       key: 'reporter',
       label: 'Reporter',

--- a/components/admin/AdminTable.js
+++ b/components/admin/AdminTable.js
@@ -5,10 +5,11 @@ import SkeletonLoader from '@/components/SkeletonLoader';
 
 /**
  * Reusable admin table component
- * @param {array} columns - Column definitions [{ key, header, render?, width? }]
+ * @param {array} columns - Column definitions [{ key, header|label, render?, width? }]
  * @param {array} data - Array of data objects to display
  * @param {function} onEdit - Edit handler (item) => void
  * @param {function} onDelete - Delete handler (item) => void
+ * @param {function} onRowClick - Row click handler (item) => void
  * @param {boolean} loading - Loading state
  * @param {string} emptyMessage - Message when no data
  * @param {string} keyField - Field to use as unique key (default: 'id')
@@ -19,12 +20,15 @@ export default function AdminTable({
   data = [],
   onEdit,
   onDelete,
+  onRowClick,
   loading = false,
   emptyMessage = 'No items found',
   keyField = 'id',
   rowClassName,
   actions = true,
 }) {
+  const getColumnTitle = (column) => column.header ?? column.label ?? column.key;
+
   if (loading) {
     return (
       <div className="bg-white shadow-md rounded-lg overflow-hidden">
@@ -37,7 +41,7 @@ export default function AdminTable({
                     key={column.key}
                     className={`px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider ${column.width || ''}`}
                   >
-                    {column.header}
+                    {getColumnTitle(column)}
                   </th>
                 ))}
                 {actions && (onEdit || onDelete) && (
@@ -75,7 +79,7 @@ export default function AdminTable({
                   key={column.key}
                   className={`px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider ${column.width || ''}`}
                 >
-                  {column.header}
+                  {getColumnTitle(column)}
                 </th>
               ))}
               {actions && (onEdit || onDelete) && (
@@ -86,30 +90,48 @@ export default function AdminTable({
             </tr>
           </thead>
           <tbody className="bg-white divide-y divide-gray-200">
-            {data.map((item) => (
-              <tr
-                key={item[keyField]}
-                className={rowClassName ? rowClassName(item) : 'hover:bg-gray-50'}
-              >
-                {columns.map((column) => (
-                  <td
-                    key={column.key}
-                    className={`px-6 py-4 text-sm text-gray-900 ${column.className || 'whitespace-nowrap'}`}
-                  >
-                    {column.render ? column.render(item) : item[column.key]}
-                  </td>
-                ))}
-                {actions && (onEdit || onDelete) && (
-                  <td className="px-6 py-4 whitespace-nowrap text-right text-sm font-medium">
-                    <AdminTableActions
-                      item={item}
-                      onEdit={onEdit}
-                      onDelete={onDelete}
-                    />
-                  </td>
-                )}
-              </tr>
-            ))}
+            {data.map((item) => {
+              const interactiveRowClass = onRowClick
+                ? 'cursor-pointer focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500'
+                : '';
+
+              return (
+                <tr
+                  key={item[keyField]}
+                  className={`${rowClassName ? rowClassName(item) : 'hover:bg-gray-50'} ${interactiveRowClass}`.trim()}
+                  onClick={onRowClick ? () => onRowClick(item) : undefined}
+                  onKeyDown={onRowClick ? (event) => {
+                    if (event.key === 'Enter' || event.key === ' ') {
+                      event.preventDefault();
+                      onRowClick(item);
+                    }
+                  } : undefined}
+                  tabIndex={onRowClick ? 0 : undefined}
+                >
+                  {columns.map((column) => (
+                    <td
+                      key={column.key}
+                      className={`px-6 py-4 text-sm text-gray-900 ${column.className || 'whitespace-nowrap'}`}
+                    >
+                      {column.render ? column.render(item) : item[column.key]}
+                    </td>
+                  ))}
+                  {actions && (onEdit || onDelete) && (
+                    <td
+                      className="px-6 py-4 whitespace-nowrap text-right text-sm font-medium"
+                      onClick={(event) => event.stopPropagation()}
+                      onKeyDown={(event) => event.stopPropagation()}
+                    >
+                      <AdminTableActions
+                        item={item}
+                        onEdit={onEdit}
+                        onDelete={onDelete}
+                      />
+                    </td>
+                  )}
+                </tr>
+              );
+            })}
           </tbody>
         </table>
       </div>


### PR DESCRIPTION
### Motivation

- Provide an admin-facing message detail view so admins and moderators can inspect individual messages. 
- Make the reusable `AdminTable` component more robust to different column shapes and enable row-level interactions. 
- Improve small rendering edge-cases in admin reports (safe `category` display).

### Description

- Add `app/admin/messages/[id]/page.js` which implements `MessageDetailContent` and wraps it with `ProtectedRoute` to fetch and display a message by id using `useAsyncData` and `messageAPI.getById` with localized date and conditional sections (sender, admin notes, response). 
- Extend `components/admin/AdminTable.js` to accept both `header` and `label` column keys via a `getColumnTitle` helper, add an optional `onRowClick` prop to make rows clickable and keyboard-accessible, and prevent action cell clicks from propagating to the row. 
- Adjust table row classes to include focus and pointer styles when `onRowClick` is provided and add `tabIndex`/keyboard handlers for `Enter` and `Space`. 
- Tweak `app/admin/reports/page.js` to safely render `category` with `row.category?.replace(/_/g, ' ') || '-'` and keep reporter fallbacks intact.

### Testing

- Ran the project's linting with `npm run lint` and fixed issues; lint checks passed. 
- Executed the test suite with `npm test` and existing unit/integration tests completed successfully. 
- Verified no runtime errors in the admin reports and table components during local manual smoke checks.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ce40b376b083218c2b2ca46e8a5a60)