### PR TITLE
Responsive AdminTable, message detail page, and small robustness fixes

### DIFF
--- a/app/admin/candidates/page.js
+++ b/app/admin/candidates/page.js
@@ -110,10 +110,10 @@ export default function AdminCandidatesPage() {
               <thead className="bg-gray-50">
                 <tr>
                   <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wide">Name</th>
-                  <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wide">Constituency</th>
+                  <th className="hidden lg:table-cell px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wide">Constituency</th>
                   <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wide">Status</th>
                   <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wide">Active</th>
-                  <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wide">Source</th>
+                  <th className="hidden xl:table-cell px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wide">Source</th>
                   <th className="px-4 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wide">Actions</th>
                 </tr>
               </thead>
@@ -129,10 +129,10 @@ export default function AdminCandidatesPage() {
                         </div>
                       </div>
                     </td>
-                    <td className="px-4 py-3 text-sm text-gray-600">{p.constituency?.name || '—'}</td>
+                    <td className="hidden lg:table-cell px-4 py-3 text-sm text-gray-600">{p.constituency?.name || '—'}</td>
                     <td className="px-4 py-3"><ClaimBadge status={p.claimStatus} /></td>
                     <td className="px-4 py-3"><ActiveBadge isActive={p.isActiveCandidate} /></td>
-                    <td className="px-4 py-3 text-sm text-gray-500">{p.source}</td>
+                    <td className="hidden xl:table-cell px-4 py-3 text-sm text-gray-500">{p.source}</td>
                     <td className="px-4 py-3 text-right">
                       <div className="flex items-center justify-end gap-2">
                         <Link href={`/admin/candidates/${p.id}/edit`} className="p-1.5 text-gray-500 hover:text-blue-600 rounded">

--- a/app/admin/messages/[id]/page.js
+++ b/app/admin/messages/[id]/page.js
@@ -1,0 +1,110 @@
+'use client';
+
+import Link from 'next/link';
+import { useParams } from 'next/navigation';
+import ProtectedRoute from '@/components/ProtectedRoute';
+import Card from '@/components/Card';
+import { useAsyncData } from '@/hooks/useAsyncData';
+import { messageAPI } from '@/lib/api';
+
+function MessageDetailContent() {
+  const params = useParams();
+  const messageId = params?.id;
+
+  const { data: message, loading, error } = useAsyncData(
+    async () => {
+      if (!messageId) return null;
+      const response = await messageAPI.getById(messageId);
+      if (response.success) {
+        return response.data?.message || null;
+      }
+      return null;
+    },
+    [messageId],
+    { initialData: null }
+  );
+
+  return (
+    <div className="bg-gray-50 min-h-screen py-8">
+      <div className="app-container max-w-4xl mx-auto px-4 sm:px-6 lg:px-8">
+        <div className="mb-6">
+          <Link href="/admin/messages" className="text-sm text-blue-600 hover:text-blue-800 font-medium">
+            ← Επιστροφή στα μηνύματα
+          </Link>
+          <h1 className="text-3xl font-bold mt-2">Λεπτομέρειες Μηνύματος</h1>
+        </div>
+
+        {loading && (
+          <Card>
+            <p className="text-gray-500">Φόρτωση...</p>
+          </Card>
+        )}
+
+        {error && (
+          <Card>
+            <p className="text-red-600">Αποτυχία φόρτωσης μηνύματος.</p>
+          </Card>
+        )}
+
+        {!loading && !error && !message && (
+          <Card>
+            <p className="text-gray-600">Το μήνυμα δεν βρέθηκε.</p>
+          </Card>
+        )}
+
+        {!loading && !error && message && (
+          <Card>
+            <div className="space-y-4">
+              <div>
+                <h2 className="text-xl font-semibold text-gray-900">{message.subject}</h2>
+                <p className="text-sm text-gray-500 mt-1">
+                  {new Date(message.createdAt).toLocaleDateString('el-GR', {
+                    day: 'numeric',
+                    month: 'long',
+                    year: 'numeric',
+                    hour: '2-digit',
+                    minute: '2-digit'
+                  })}
+                </p>
+              </div>
+
+              <div className="border-t pt-4">
+                <h3 className="text-sm font-semibold text-gray-700 mb-1">Αποστολέας</h3>
+                <p className="text-gray-900">
+                  {message.user ? `${message.user.username} (${message.user.email})` : `${message.name} (${message.email})`}
+                </p>
+              </div>
+
+              <div className="border-t pt-4">
+                <h3 className="text-sm font-semibold text-gray-700 mb-1">Μήνυμα</h3>
+                <p className="text-gray-900 whitespace-pre-wrap">{message.message}</p>
+              </div>
+
+              {message.adminNotes && (
+                <div className="border-t pt-4">
+                  <h3 className="text-sm font-semibold text-gray-700 mb-1">Admin Notes</h3>
+                  <p className="text-gray-900 whitespace-pre-wrap">{message.adminNotes}</p>
+                </div>
+              )}
+
+              {message.response && (
+                <div className="border-t pt-4">
+                  <h3 className="text-sm font-semibold text-green-700 mb-1">Απάντηση</h3>
+                  <p className="text-gray-900 whitespace-pre-wrap">{message.response}</p>
+                </div>
+              )}
+            </div>
+          </Card>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export default function AdminMessageDetailPage() {
+  return (
+    <ProtectedRoute allowedRoles={['admin', 'moderator']}>
+      <MessageDetailContent />
+    </ProtectedRoute>
+  );
+}

--- a/app/admin/persons/page.js
+++ b/app/admin/persons/page.js
@@ -101,11 +101,11 @@ export default function AdminPersonsPage() {
               <thead className="bg-gray-50">
                 <tr>
                   <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wide">Όνομα</th>
-                  <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wide">Τοποθεσία</th>
-                  <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wide">Εκλογική Περιφέρεια</th>
+                  <th className="hidden lg:table-cell px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wide">Τοποθεσία</th>
+                  <th className="hidden xl:table-cell px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wide">Εκλογική Περιφέρεια</th>
                   <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wide">Κατάσταση</th>
                   <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wide">Ενεργός</th>
-                  <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wide">Πηγή</th>
+                  <th className="hidden lg:table-cell px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wide">Πηγή</th>
                   <th className="px-4 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wide">Ενέργειες</th>
                 </tr>
               </thead>
@@ -118,11 +118,11 @@ export default function AdminPersonsPage() {
                       </Link>
                       <p className="text-xs text-gray-400">/{p.slug}</p>
                     </td>
-                    <td className="px-4 py-3 text-sm text-gray-600">{p.location?.name || '—'}</td>
-                    <td className="px-4 py-3 text-sm text-gray-600">{p.constituency?.name || '—'}</td>
+                    <td className="hidden lg:table-cell px-4 py-3 text-sm text-gray-600">{p.location?.name || '—'}</td>
+                    <td className="hidden xl:table-cell px-4 py-3 text-sm text-gray-600">{p.constituency?.name || '—'}</td>
                     <td className="px-4 py-3"><ClaimBadge status={p.claimStatus} /></td>
                     <td className="px-4 py-3"><ActiveBadge isActive={p.isActiveCandidate} /></td>
-                    <td className="px-4 py-3 text-sm text-gray-500">{p.source}</td>
+                    <td className="hidden lg:table-cell px-4 py-3 text-sm text-gray-500">{p.source}</td>
                     <td className="px-4 py-3 text-right">
                       <div className="flex items-center justify-end gap-2">
                         <Link href={`/admin/persons/${p.id}/edit`} className="p-1.5 text-gray-500 hover:text-blue-600 rounded">

--- a/app/admin/reports/page.js
+++ b/app/admin/reports/page.js
@@ -135,7 +135,7 @@ function ReportsContent() {
         );
       }
     },
-    { key: 'category', label: 'Category', render: (row) => row.category.replace(/_/g, ' ') },
+    { key: 'category', label: 'Category', render: (row) => row.category?.replace(/_/g, ' ') || '-' },
     {
       key: 'reporter',
       label: 'Reporter',

--- a/components/admin/AdminTable.js
+++ b/components/admin/AdminTable.js
@@ -5,10 +5,11 @@ import SkeletonLoader from '@/components/SkeletonLoader';
 
 /**
  * Reusable admin table component
- * @param {array} columns - Column definitions [{ key, header, render?, width? }]
+ * @param {array} columns - Column definitions [{ key, header|label, render?, width? }]
  * @param {array} data - Array of data objects to display
  * @param {function} onEdit - Edit handler (item) => void
  * @param {function} onDelete - Delete handler (item) => void
+ * @param {function} onRowClick - Row click handler (item) => void
  * @param {boolean} loading - Loading state
  * @param {string} emptyMessage - Message when no data
  * @param {string} keyField - Field to use as unique key (default: 'id')
@@ -19,12 +20,16 @@ export default function AdminTable({
   data = [],
   onEdit,
   onDelete,
+  onRowClick,
   loading = false,
   emptyMessage = 'No items found',
   keyField = 'id',
   rowClassName,
   actions = true,
 }) {
+  const getColumnTitle = (column) => column.header ?? column.label ?? column.key;
+  const renderCell = (column, item) => (column.render ? column.render(item) : item[column.key]);
+
   if (loading) {
     return (
       <div className="bg-white shadow-md rounded-lg overflow-hidden">
@@ -37,7 +42,7 @@ export default function AdminTable({
                     key={column.key}
                     className={`px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider ${column.width || ''}`}
                   >
-                    {column.header}
+                    {getColumnTitle(column)}
                   </th>
                 ))}
                 {actions && (onEdit || onDelete) && (
@@ -66,7 +71,46 @@ export default function AdminTable({
 
   return (
     <div className="bg-white shadow-md rounded-lg overflow-hidden">
-      <div className="overflow-x-auto">
+      {/* Mobile card layout: avoids horizontal scrolling */}
+      <div className="md:hidden divide-y divide-gray-200">
+        {data.map((item) => (
+          <div
+            key={item[keyField]}
+            className={`p-4 space-y-3 ${onRowClick ? 'cursor-pointer' : ''}`}
+            onClick={onRowClick ? () => onRowClick(item) : undefined}
+            onKeyDown={onRowClick ? (event) => {
+              if (event.key === 'Enter' || event.key === ' ') {
+                event.preventDefault();
+                onRowClick(item);
+              }
+            } : undefined}
+            tabIndex={onRowClick ? 0 : undefined}
+          >
+            {columns.map((column) => (
+              <div key={column.key} className="flex flex-col gap-1">
+                <span className="text-xs font-semibold uppercase tracking-wide text-gray-500">
+                  {getColumnTitle(column)}
+                </span>
+                <div className="text-sm text-gray-900 break-words">
+                  {renderCell(column, item)}
+                </div>
+              </div>
+            ))}
+            {actions && (onEdit || onDelete) && (
+              <div
+                className="pt-1"
+                onClick={(event) => event.stopPropagation()}
+                onKeyDown={(event) => event.stopPropagation()}
+              >
+                <AdminTableActions item={item} onEdit={onEdit} onDelete={onDelete} />
+              </div>
+            )}
+          </div>
+        ))}
+      </div>
+
+      {/* Desktop table layout */}
+      <div className="hidden md:block overflow-x-auto">
         <table className="min-w-full divide-y divide-gray-200">
           <thead className="bg-gray-50">
             <tr>
@@ -75,7 +119,7 @@ export default function AdminTable({
                   key={column.key}
                   className={`px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider ${column.width || ''}`}
                 >
-                  {column.header}
+                  {getColumnTitle(column)}
                 </th>
               ))}
               {actions && (onEdit || onDelete) && (
@@ -86,30 +130,48 @@ export default function AdminTable({
             </tr>
           </thead>
           <tbody className="bg-white divide-y divide-gray-200">
-            {data.map((item) => (
-              <tr
-                key={item[keyField]}
-                className={rowClassName ? rowClassName(item) : 'hover:bg-gray-50'}
-              >
-                {columns.map((column) => (
-                  <td
-                    key={column.key}
-                    className={`px-6 py-4 text-sm text-gray-900 ${column.className || 'whitespace-nowrap'}`}
-                  >
-                    {column.render ? column.render(item) : item[column.key]}
-                  </td>
-                ))}
-                {actions && (onEdit || onDelete) && (
-                  <td className="px-6 py-4 whitespace-nowrap text-right text-sm font-medium">
-                    <AdminTableActions
-                      item={item}
-                      onEdit={onEdit}
-                      onDelete={onDelete}
-                    />
-                  </td>
-                )}
-              </tr>
-            ))}
+            {data.map((item) => {
+              const interactiveRowClass = onRowClick
+                ? 'cursor-pointer focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500'
+                : '';
+
+              return (
+                <tr
+                  key={item[keyField]}
+                  className={`${rowClassName ? rowClassName(item) : 'hover:bg-gray-50'} ${interactiveRowClass}`.trim()}
+                  onClick={onRowClick ? () => onRowClick(item) : undefined}
+                  onKeyDown={onRowClick ? (event) => {
+                    if (event.key === 'Enter' || event.key === ' ') {
+                      event.preventDefault();
+                      onRowClick(item);
+                    }
+                  } : undefined}
+                  tabIndex={onRowClick ? 0 : undefined}
+                >
+                  {columns.map((column) => (
+                    <td
+                      key={column.key}
+                      className={`px-6 py-4 text-sm text-gray-900 ${column.className || 'whitespace-normal break-words'}`}
+                    >
+                      {renderCell(column, item)}
+                    </td>
+                  ))}
+                  {actions && (onEdit || onDelete) && (
+                    <td
+                      className="px-6 py-4 whitespace-nowrap text-right text-sm font-medium"
+                      onClick={(event) => event.stopPropagation()}
+                      onKeyDown={(event) => event.stopPropagation()}
+                    >
+                      <AdminTableActions
+                        item={item}
+                        onEdit={onEdit}
+                        onDelete={onDelete}
+                      />
+                    </td>
+                  )}
+                </tr>
+              );
+            })}
           </tbody>
         </table>
       </div>


### PR DESCRIPTION
### Motivation
- Improve admin listing UX on mobile and add keyboard accessibility for table rows.
- Provide a detailed admin message view for moderators and admins.
- Prevent runtime errors when optional report fields are missing.

### Description
- Refactored `components/admin/AdminTable.js` to accept `header`/`label` keys, added `onRowClick` support, a mobile card layout (`md:hidden`), keyboard handlers (`onKeyDown`/`tabIndex`), and helpers `getColumnTitle` and `renderCell`, while keeping action buttons via `AdminTableActions`.
- Added a new client page `app/admin/messages/[id]/page.js` that fetches a message via `useAsyncData`, wraps the UI in `ProtectedRoute`, and renders message metadata and content (UI strings in Greek).
- Updated `app/admin/candidates/page.js` and `app/admin/persons/page.js` to hide less-critical columns on small screens using `hidden lg:table-cell` and `hidden xl:table-cell` to reduce horizontal scrolling.
- Made `app/admin/reports/page.js` resilient to missing categories by changing the renderer to `row.category?.replace(/_/g, ' ') || '-'`.

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ce40b376b083218c2b2ca46e8a5a60)