### PR TITLE
Fix geo IP detection returning unknown country for valid US addresses

### DIFF
--- a/src/middleware/countryBlockMiddleware.js
+++ b/src/middleware/countryBlockMiddleware.js
@@ -22,6 +22,10 @@ const getClientIp = (req) => {
 const detectCountryCode = (req) => {
   const cfCountry = normalizeCountryCode(req.headers['cf-ipcountry']);
   if (cfCountry) return cfCountry;
+  const vercelCountry = normalizeCountryCode(req.headers['x-vercel-ip-country']);
+  if (vercelCountry) return vercelCountry;
+  const genericCountry = normalizeCountryCode(req.headers['x-country-code']);
+  if (genericCountry) return genericCountry;
   return normalizeCountryCode(req.headers['x-detected-country']);
 };
 

--- a/src/routes/__tests__/geoDetectRoutes.test.js
+++ b/src/routes/__tests__/geoDetectRoutes.test.js
@@ -1,0 +1,40 @@
+const { normalizeCountryCode, parseClientIp } = require('../geoDetectRoutes');
+
+describe('geoDetectRoutes helpers', () => {
+  describe('normalizeCountryCode', () => {
+    it('normalizes lowercase ISO country codes', () => {
+      expect(normalizeCountryCode('us')).toBe('US');
+    });
+
+    it('rejects special unknown Cloudflare country codes', () => {
+      expect(normalizeCountryCode('XX')).toBeNull();
+      expect(normalizeCountryCode('t1')).toBeNull();
+    });
+
+    it('rejects invalid country values', () => {
+      expect(normalizeCountryCode('USA')).toBeNull();
+      expect(normalizeCountryCode('1A')).toBeNull();
+      expect(normalizeCountryCode('')).toBeNull();
+    });
+  });
+
+  describe('parseClientIp', () => {
+    it('prefers the first x-forwarded-for IP', () => {
+      const req = {
+        headers: { 'x-forwarded-for': '203.0.113.10, 10.0.0.2' },
+        ip: '10.0.0.2',
+      };
+      expect(parseClientIp(req)).toBe('203.0.113.10');
+    });
+
+    it('strips IPv4-mapped IPv6 prefixes', () => {
+      const req = { headers: {}, ip: '::ffff:198.51.100.4' };
+      expect(parseClientIp(req)).toBe('198.51.100.4');
+    });
+
+    it('returns null for loopback IPs', () => {
+      expect(parseClientIp({ headers: {}, ip: '127.0.0.1' })).toBeNull();
+      expect(parseClientIp({ headers: {}, ip: '::1' })).toBeNull();
+    });
+  });
+});

--- a/src/routes/geoDetectRoutes.js
+++ b/src/routes/geoDetectRoutes.js
@@ -19,19 +19,48 @@ const COUNTRY_NAMES = {
   AE: 'United Arab Emirates', SA: 'Saudi Arabia',
 };
 
+const INVALID_COUNTRY_CODES = new Set(['XX', 'T1']);
+
+const normalizeCountryCode = (value) => {
+  if (!value) return null;
+  const normalized = String(value).trim().toUpperCase();
+  if (!/^[A-Z]{2}$/.test(normalized)) return null;
+  if (INVALID_COUNTRY_CODES.has(normalized)) return null;
+  return normalized;
+};
+
+const parseClientIp = (req) => {
+  const forwardedFor = req.headers['x-forwarded-for'];
+  const fromForwarded = Array.isArray(forwardedFor) ? forwardedFor[0] : forwardedFor;
+  const candidate = (fromForwarded ? String(fromForwarded).split(',')[0] : null)
+    || req.headers['x-real-ip']
+    || req.headers['cf-connecting-ip']
+    || req.ip
+    || req.connection?.remoteAddress
+    || null;
+
+  if (!candidate) return null;
+  const cleaned = String(candidate).trim().replace(/^::ffff:/i, '');
+  if (!cleaned || cleaned === '::1' || cleaned === '127.0.0.1') return null;
+  return cleaned;
+};
+
 router.get('/detect', apiLimiter, (req, res) => {
   try {
-    let countryCode = req.headers['cf-ipcountry'] || null;
-    if (countryCode === 'XX' || countryCode === 'T1') countryCode = null;
+    let countryCode = normalizeCountryCode(
+      req.headers['cf-ipcountry']
+      || req.headers['x-vercel-ip-country']
+      || req.headers['x-country-code']
+    );
 
     if (!countryCode) {
       try {
         // Optional dependency (fallback only)
         const geoip = require('geoip-lite');
-        const ip = req.ip || req.connection?.remoteAddress;
+        const ip = parseClientIp(req);
         if (ip) {
           const geo = geoip.lookup(ip);
-          if (geo?.country) countryCode = geo.country;
+          countryCode = normalizeCountryCode(geo?.country);
         }
       } catch {
         // geoip-lite not installed
@@ -46,3 +75,5 @@ router.get('/detect', apiLimiter, (req, res) => {
 });
 
 module.exports = router;
+module.exports.normalizeCountryCode = normalizeCountryCode;
+module.exports.parseClientIp = parseClientIp;


### PR DESCRIPTION
### Motivation
- Fix cases where the geo-detect endpoint returned an unknown country (e.g. `us`) due to inconsistent header handling and unnormalized country codes. 
- Make fallback IP-based lookup more reliable when the app runs behind proxies/CDNs.
- Ensure the country-block middleware respects additional platform headers so legitimate requests are not treated as "unknown country".

### Description
- Add `normalizeCountryCode` to validate and normalize incoming country headers to uppercase ISO-2 and to treat placeholders like `XX`/`T1` as unknown. 
- Add `parseClientIp` to prefer `x-forwarded-for`, support `x-real-ip`/`cf-connecting-ip`, strip `::ffff:` IPv4-mapped IPv6 prefixes and ignore loopback addresses before geo lookup. 
- Read additional country headers (`x-vercel-ip-country`, `x-country-code`) in the geo detect route and in `countryBlockMiddleware` as fallbacks to Cloudflare headers. 
- Add focused unit tests for `normalizeCountryCode` and `parseClientIp` in `src/routes/__tests__/geoDetectRoutes.test.js` and export the helpers for testing.

### Testing
- Added and ran unit tests with `npm test -- --runInBand src/routes/__tests__/geoDetectRoutes.test.js`, and all tests passed. 
- The new tests cover lowercase normalization, invalid placeholders (`XX`, `T1`), `x-forwarded-for` parsing, IPv4-mapped IPv6 cleaning and loopback handling.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea001d550c83218ddc7ab889ed12b3)