### PR TITLE
Normalize client IP parsing in geo detect route and add tests

### DIFF
--- a/src/routes/__tests__/geoDetectRoutes.test.js
+++ b/src/routes/__tests__/geoDetectRoutes.test.js
@@ -32,6 +32,16 @@ describe('geoDetectRoutes helpers', () => {
       expect(parseClientIp(req)).toBe('198.51.100.4');
     });
 
+
+    it('strips IPv4 port suffixes', () => {
+      const req = { headers: { 'x-forwarded-for': '203.0.113.10:443' }, ip: '10.0.0.2' };
+      expect(parseClientIp(req)).toBe('203.0.113.10');
+    });
+
+    it('unwraps bracketed IPv6 values', () => {
+      const req = { headers: { 'x-real-ip': '[2001:db8::1]:8443' }, ip: '10.0.0.2' };
+      expect(parseClientIp(req)).toBe('2001:db8::1');
+    });
     it('returns null for loopback IPs', () => {
       expect(parseClientIp({ headers: {}, ip: '127.0.0.1' })).toBeNull();
       expect(parseClientIp({ headers: {}, ip: '::1' })).toBeNull();

--- a/src/routes/geoDetectRoutes.js
+++ b/src/routes/geoDetectRoutes.js
@@ -1,5 +1,6 @@
 const express = require('express');
 const { apiLimiter } = require('../middleware/rateLimiter');
+const { normalizeIp } = require('../utils/normalizeIp');
 
 const router = express.Router();
 
@@ -40,7 +41,8 @@ const parseClientIp = (req) => {
     || null;
 
   if (!candidate) return null;
-  const cleaned = String(candidate).trim().replace(/^::ffff:/i, '');
+
+  const cleaned = normalizeIp(candidate);
   if (!cleaned || cleaned === '::1' || cleaned === '127.0.0.1') return null;
   return cleaned;
 };


### PR DESCRIPTION
### Motivation
- The `parseClientIp` helper in the geo detect route did inline string cleanup which missed some valid header formats (IPv4 with port, bracketed IPv6) and caused inconsistent geo IP detection. 

### Description
- Replace manual cleanup in `parseClientIp` with the shared `normalizeIp` utility by importing `normalizeIp` from `src/utils/normalizeIp` and using it to canonicalize the candidate IP. 
- Preserve existing loopback filtering (`::1`, `127.0.0.1`) after normalization. 
- Add tests in `src/routes/__tests__/geoDetectRoutes.test.js` covering IPv4-with-port and bracketed IPv6 header formats. 
- Files modified: `src/routes/geoDetectRoutes.js` and `src/routes/__tests__/geoDetectRoutes.test.js`.

### Testing
- Ran the geo detect unit tests with `npm test -- --runInBand src/routes/__tests__/geoDetectRoutes.test.js`, and the suite passed. 
- Also ran the combined geo-related tests with `npm test -- --runInBand __tests__/geo-detect-routes.test.js src/routes/__tests__/geoDetectRoutes.test.js`, and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f1eb1a6ed8832186ed850bbe4eb27a)