### PR TITLE
Switch endorsements to relationship verification types

### DIFF
--- a/__tests__/endorsements.test.js
+++ b/__tests__/endorsements.test.js
@@ -64,13 +64,13 @@ describe('Endorsement System Tests', () => {
   // ── Topics endpoint ──────────────────────────────────────────────────────
 
   describe('GET /api/endorsements/topics', () => {
-    it('returns the list of valid topics', async () => {
+    it('returns the list of valid relationship endorsement types', async () => {
       const res = await request(app).get('/api/endorsements/topics');
       expect(res.status).toBe(200);
       expect(res.body.success).toBe(true);
       expect(Array.isArray(res.body.data.topics)).toBe(true);
-      expect(res.body.data.topics).toContain('Education');
-      expect(res.body.data.topics).toContain('Technology');
+      expect(res.body.data.topics).toContain('Real Profile');
+      expect(res.body.data.topics).toContain('Local Connection');
     });
   });
 
@@ -82,7 +82,7 @@ describe('Endorsement System Tests', () => {
         .post('/api/endorsements')
         .set('Authorization', `Bearer ${userAToken}`)
         .set(csrfHeaders(userAId))
-        .send({ endorsedUserId: userBId, topic: 'Education' });
+        .send({ endorsedUserId: userBId, topic: 'Real Profile' });
 
       expect(res.status).toBe(200);
       expect(res.body.success).toBe(true);
@@ -95,14 +95,14 @@ describe('Endorsement System Tests', () => {
         .post('/api/endorsements')
         .set('Authorization', `Bearer ${userAToken}`)
         .set(csrfHeaders(userAId))
-        .send({ endorsedUserId: userBId, topic: 'Health' });
+        .send({ endorsedUserId: userBId, topic: 'Knows Personally' });
 
       // Duplicate endorsement
       const res = await request(app)
         .post('/api/endorsements')
         .set('Authorization', `Bearer ${userAToken}`)
         .set(csrfHeaders(userAId))
-        .send({ endorsedUserId: userBId, topic: 'Health' });
+        .send({ endorsedUserId: userBId, topic: 'Knows Personally' });
 
       expect(res.status).toBe(200);
       expect(res.body.success).toBe(true);
@@ -114,7 +114,7 @@ describe('Endorsement System Tests', () => {
         .post('/api/endorsements')
         .set('Authorization', `Bearer ${userAToken}`)
         .set(csrfHeaders(userAId))
-        .send({ endorsedUserId: userAId, topic: 'Economy' });
+        .send({ endorsedUserId: userAId, topic: 'Worked Together' });
 
       expect(res.status).toBe(400);
       expect(res.body.success).toBe(false);
@@ -124,7 +124,7 @@ describe('Endorsement System Tests', () => {
     it('rejects unauthenticated requests', async () => {
       const res = await request(app)
         .post('/api/endorsements')
-        .send({ endorsedUserId: userBId, topic: 'Technology' });
+        .send({ endorsedUserId: userBId, topic: 'Local Connection' });
 
       expect(res.status).toBe(401);
     });
@@ -145,7 +145,7 @@ describe('Endorsement System Tests', () => {
         .post('/api/endorsements')
         .set('Authorization', `Bearer ${userAToken}`)
         .set(csrfHeaders(userAId))
-        .send({ endorsedUserId: 999999, topic: 'Technology' });
+        .send({ endorsedUserId: 999999, topic: 'Local Connection' });
 
       expect(res.status).toBe(404);
     });
@@ -157,7 +157,7 @@ describe('Endorsement System Tests', () => {
     beforeAll(async () => {
       // Ensure endorsement exists before delete tests
       await Endorsement.findOrCreate({
-        where: { endorserId: userAId, endorsedId: userBId, topic: 'Environment' }
+        where: { endorserId: userAId, endorsedId: userBId, topic: 'Worked Together' }
       });
     });
 
@@ -166,7 +166,7 @@ describe('Endorsement System Tests', () => {
         .delete('/api/endorsements')
         .set('Authorization', `Bearer ${userAToken}`)
         .set(csrfHeaders(userAId))
-        .send({ endorsedUserId: userBId, topic: 'Environment' });
+        .send({ endorsedUserId: userBId, topic: 'Worked Together' });
 
       expect(res.status).toBe(200);
       expect(res.body.success).toBe(true);
@@ -178,7 +178,7 @@ describe('Endorsement System Tests', () => {
         .delete('/api/endorsements')
         .set('Authorization', `Bearer ${userAToken}`)
         .set(csrfHeaders(userAId))
-        .send({ endorsedUserId: userBId, topic: 'Technology' });
+        .send({ endorsedUserId: userBId, topic: 'Local Connection' });
 
       expect(res.status).toBe(200);
       expect(res.body.success).toBe(true);
@@ -188,7 +188,7 @@ describe('Endorsement System Tests', () => {
     it('rejects unauthenticated requests', async () => {
       const res = await request(app)
         .delete('/api/endorsements')
-        .send({ endorsedUserId: userBId, topic: 'Education' });
+        .send({ endorsedUserId: userBId, topic: 'Real Profile' });
 
       expect(res.status).toBe(401);
     });
@@ -198,12 +198,12 @@ describe('Endorsement System Tests', () => {
 
   describe('GET /api/endorsements/status', () => {
     beforeAll(async () => {
-      // Setup: userC endorses userB for Education and Economy
+      // Setup: userC endorses userB for profile authenticity and personal knowledge
       await Endorsement.findOrCreate({
-        where: { endorserId: userCId, endorsedId: userBId, topic: 'Education' }
+        where: { endorserId: userCId, endorsedId: userBId, topic: 'Real Profile' }
       });
       await Endorsement.findOrCreate({
-        where: { endorserId: userCId, endorsedId: userBId, topic: 'Economy' }
+        where: { endorserId: userCId, endorsedId: userBId, topic: 'Knows Personally' }
       });
     });
 
@@ -214,8 +214,8 @@ describe('Endorsement System Tests', () => {
 
       expect(res.status).toBe(200);
       expect(res.body.success).toBe(true);
-      expect(res.body.data.endorsedTopics).toContain('Education');
-      expect(res.body.data.endorsedTopics).toContain('Economy');
+      expect(res.body.data.endorsedTopics).toContain('Real Profile');
+      expect(res.body.data.endorsedTopics).toContain('Knows Personally');
     });
 
     it('returns per-topic counts for the target user', async () => {
@@ -225,15 +225,18 @@ describe('Endorsement System Tests', () => {
 
       expect(res.status).toBe(200);
       expect(res.body.data.topicCounts).toBeDefined();
-      expect(res.body.data.topicCounts['Education']).toBeGreaterThanOrEqual(1);
-      expect(res.body.data.topicCounts['Economy']).toBeGreaterThanOrEqual(1);
+      expect(res.body.data.topicCounts['Real Profile']).toBeGreaterThanOrEqual(1);
+      expect(res.body.data.topicCounts['Knows Personally']).toBeGreaterThanOrEqual(1);
     });
 
-    it('rejects unauthenticated requests', async () => {
+    it('returns public counts without authentication', async () => {
       const res = await request(app)
         .get(`/api/endorsements/status?userId=${userBId}`);
 
-      expect(res.status).toBe(401);
+      expect(res.status).toBe(200);
+      expect(res.body.success).toBe(true);
+      expect(res.body.data.endorsedTopics).toEqual([]);
+      expect(res.body.data.topicCounts['Real Profile']).toBeGreaterThanOrEqual(1);
     });
 
     it('returns 400 for missing userId', async () => {
@@ -251,20 +254,20 @@ describe('Endorsement System Tests', () => {
     beforeAll(async () => {
       // Setup: ensure userB has more endorsements than userC
       await Endorsement.findOrCreate({
-        where: { endorserId: userAId, endorsedId: userBId, topic: 'Technology' }
+        where: { endorserId: userAId, endorsedId: userBId, topic: 'Local Connection' }
       });
       await Endorsement.findOrCreate({
-        where: { endorserId: userCId, endorsedId: userBId, topic: 'Technology' }
+        where: { endorserId: userCId, endorsedId: userBId, topic: 'Local Connection' }
       });
-      // userC gets 1 endorsement for Technology
+      // userC gets 1 endorsement for Local Connection
       await Endorsement.findOrCreate({
-        where: { endorserId: userAId, endorsedId: userCId, topic: 'Technology' }
+        where: { endorserId: userAId, endorsedId: userCId, topic: 'Local Connection' }
       });
     });
 
     it('returns users ranked by endorsement count (descending)', async () => {
       const res = await request(app)
-        .get('/api/endorsements/leaderboard?topic=Technology');
+        .get('/api/endorsements/leaderboard?topic=Local%20Connection');
 
       expect(res.status).toBe(200);
       expect(res.body.success).toBe(true);
@@ -280,11 +283,11 @@ describe('Endorsement System Tests', () => {
 
     it('filters by topic correctly', async () => {
       const res = await request(app)
-        .get('/api/endorsements/leaderboard?topic=Education');
+        .get('/api/endorsements/leaderboard?topic=Real%20Profile');
 
       expect(res.status).toBe(200);
       const users = res.body.data.users;
-      // All users returned should have at least 1 endorsement for Education
+      // All users returned should have at least 1 endorsement for Real Profile
       expect(users.every((u) => u.endorsementCount >= 1)).toBe(true);
     });
 

--- a/app/worthy-citizens/page.js
+++ b/app/worthy-citizens/page.js
@@ -10,23 +10,19 @@ import Link from 'next/link';
 import LoadMoreTrigger from '@/components/ui/LoadMoreTrigger';
 
 const TOPICS = [
-  'Education',
-  'Economy',
-  'Health',
-  'Environment',
-  'Local Governance',
-  'Technology',
+  'Real Profile',
+  'Knows Personally',
+  'Worked Together',
+  'Local Connection',
 ];
 
 const PAGE_SIZE = 20;
 
 const TOPIC_LABELS = {
-  Education: 'Παιδεία',
-  Economy: 'Οικονομία',
-  Health: 'Υγεία',
-  Environment: 'Περιβάλλον',
-  'Local Governance': 'Τοπική Αυτοδιοίκηση',
-  Technology: 'Τεχνολογία',
+  'Real Profile': 'Πραγματικό προφίλ',
+  'Knows Personally': 'Προσωπική γνωριμία',
+  'Worked Together': 'Συνεργασία',
+  'Local Connection': 'Τοπική σύνδεση',
 };
 
 const DEFAULT_AVATAR_COLOR = '#64748b';
@@ -72,7 +68,7 @@ function UserLeaderboardCard({ user, rank }) {
       </div>
       <div className="text-right flex-shrink-0">
         <p className="text-2xl font-bold text-blue-600">{user.endorsementCount}</p>
-        <p className="text-xs text-gray-500">εγκρίσεις</p>
+        <p className="text-xs text-gray-500">επιβεβαιώσεις</p>
       </div>
     </Link>
   );
@@ -109,9 +105,9 @@ export default function WorthyCitizensPage() {
     <div className="bg-gray-50 min-h-screen py-8">
       <div className="app-container max-w-3xl mx-auto px-4">
         <div className="mb-8">
-          <h1 className="text-3xl font-bold text-gray-900 mb-2">Αναγνωρισμένοι από την Κοινότητα</h1>
+          <h1 className="text-3xl font-bold text-gray-900 mb-2">Επιβεβαιωμένοι από την κοινότητα</h1>
           <p className="text-gray-600">
-            Κατάταξη βάσει εγκρίσεων από άλλους πολίτες ανά θεματική περιοχή.
+            Συγκεντρωτικές επιβεβαιώσεις πραγματικών σχέσεων, γνωριμίας και τοπικής σύνδεσης.
           </p>
         </div>
 
@@ -146,7 +142,7 @@ export default function WorthyCitizensPage() {
         {!initialLoading && (
           <p className="text-sm text-gray-500 mb-4">
             {totalItems} πολίτες βρέθηκαν
-            {selectedTopic ? ` για θέμα: ${TOPIC_LABELS[selectedTopic]}` : ''}
+            {selectedTopic ? ` για: ${TOPIC_LABELS[selectedTopic]}` : ''}
           </p>
         )}
 
@@ -165,8 +161,8 @@ export default function WorthyCitizensPage() {
             title="Δεν βρέθηκαν αποτελέσματα"
             description={
               selectedTopic
-                ? `Δεν υπάρχουν ακόμα εγκρίσεις για το θέμα "${TOPIC_LABELS[selectedTopic]}".`
-                : 'Δεν υπάρχουν ακόμα εγκρίσεις. Γίνετε ο πρώτος που θα εγκρίνει έναν συμπολίτη!'
+                ? `Δεν υπάρχουν ακόμα επιβεβαιώσεις για "${TOPIC_LABELS[selectedTopic]}".`
+                : 'Δεν υπάρχουν ακόμα επιβεβαιώσεις κοινότητας.'
             }
           />
         ) : (

--- a/components/EndorsementPanel.js
+++ b/components/EndorsementPanel.js
@@ -4,25 +4,27 @@ import { useState, useEffect, useCallback } from 'react';
 import { endorsementAPI } from '@/lib/api';
 import { useAuth } from '@/lib/auth-context';
 import { useToast } from '@/components/ToastProvider';
-import Link from 'next/link';
 import LoginLink from '@/components/ui/LoginLink';
 
 const TOPICS = [
-  'Education',
-  'Economy',
-  'Health',
-  'Environment',
-  'Local Governance',
-  'Technology',
+  'Real Profile',
+  'Knows Personally',
+  'Worked Together',
+  'Local Connection',
 ];
 
 const TOPIC_LABELS = {
-  Education: 'Παιδεία',
-  Economy: 'Οικονομία',
-  Health: 'Υγεία',
-  Environment: 'Περιβάλλον',
-  'Local Governance': 'Τοπική Αυτοδιοίκηση',
-  Technology: 'Τεχνολογία',
+  'Real Profile': 'Πραγματικό προφίλ',
+  'Knows Personally': 'Τον/την γνωρίζω',
+  'Worked Together': 'Έχουμε συνεργαστεί',
+  'Local Connection': 'Τοπική σύνδεση',
+};
+
+const TOPIC_HELPERS = {
+  'Real Profile': 'Το προφίλ αντιστοιχεί στο πραγματικό πρόσωπο.',
+  'Knows Personally': 'Υπάρχει προσωπική γνωριμία με αυτό το άτομο.',
+  'Worked Together': 'Υπήρξε συνεργασία σε εργασία, ομάδα ή δράση.',
+  'Local Connection': 'Υπάρχει σύνδεση με την κοινότητα ή την περιοχή.',
 };
 
 export default function EndorsementPanel({ targetUserId }) {
@@ -40,25 +42,17 @@ export default function EndorsementPanel({ targetUserId }) {
     if (!targetUserId) return;
     setLoadingStatus(true);
     try {
-      if (isAuthenticated && !isSelf) {
-        const res = await endorsementAPI.getStatus(targetUserId);
-        if (res.success) {
-          setEndorsedTopics(res.data.endorsedTopics || []);
-          setTopicCounts(res.data.topicCounts || {});
-        }
-      } else {
-        // Fetch public counts only (no auth)
-        const res = await endorsementAPI.getStatus(targetUserId).catch(() => null);
-        if (res?.success) {
-          setTopicCounts(res.data.topicCounts || {});
-        }
+      const res = await endorsementAPI.getStatus(targetUserId);
+      if (res?.success) {
+        setEndorsedTopics(res.data.endorsedTopics || []);
+        setTopicCounts(res.data.topicCounts || {});
       }
     } catch {
       // silently ignore
     } finally {
       setLoadingStatus(false);
     }
-  }, [targetUserId, isAuthenticated, isSelf]);
+  }, [targetUserId]);
 
   useEffect(() => {
     if (!authLoading) {
@@ -79,7 +73,7 @@ export default function EndorsementPanel({ targetUserId }) {
             ...prev,
             [topic]: Math.max(0, (prev[topic] || 0) - 1)
           }));
-          success('Η έγκριση αφαιρέθηκε.');
+          success('Η επιβεβαίωση αφαιρέθηκε.');
         }
       } else {
         const res = await endorsementAPI.endorse(targetUserId, topic);
@@ -89,7 +83,7 @@ export default function EndorsementPanel({ targetUserId }) {
             ...prev,
             [topic]: (prev[topic] || 0) + 1
           }));
-          success('Η έγκριση καταχωρίστηκε!');
+          success('Η επιβεβαίωση καταχωρίστηκε.');
         }
       }
     } catch {
@@ -99,25 +93,25 @@ export default function EndorsementPanel({ targetUserId }) {
     }
   };
 
-  const totalEndorsements = Object.values(topicCounts).reduce((a, b) => a + b, 0);
+  const totalEndorsements = TOPICS.reduce((total, topic) => total + (topicCounts[topic] || 0), 0);
 
   return (
     <div className="bg-white rounded-lg border border-gray-200 p-5">
       <div className="flex items-center justify-between mb-4">
-        <h2 className="text-base font-semibold text-gray-900">Εγκρίσεις Κοινότητας</h2>
+        <h2 className="text-base font-semibold text-gray-900">Επιβεβαιώσεις κοινότητας</h2>
         {totalEndorsements > 0 && (
           <span className="text-sm text-gray-500">{totalEndorsements} συνολικά</span>
         )}
       </div>
 
       {loadingStatus ? (
-        <div className="space-y-2">
+        <div className="grid gap-2 sm:grid-cols-2">
           {TOPICS.map((t) => (
-            <div key={t} className="h-9 bg-gray-100 animate-pulse rounded-full" />
+            <div key={t} className="h-16 bg-gray-100 animate-pulse rounded-lg" />
           ))}
         </div>
       ) : (
-        <div className="flex flex-wrap gap-2">
+        <div className="grid gap-2 sm:grid-cols-2">
           {TOPICS.map((topic) => {
             const count = topicCounts[topic] || 0;
             const endorsed = endorsedTopics.includes(topic);
@@ -131,31 +125,32 @@ export default function EndorsementPanel({ targetUserId }) {
                 disabled={isToggling || !canToggle}
                 title={
                   isSelf
-                    ? 'Δεν μπορείτε να εγκρίνετε τον εαυτό σας'
+                    ? 'Δεν μπορείτε να επιβεβαιώσετε τον εαυτό σας'
                     : !isAuthenticated
-                    ? 'Συνδεθείτε για να εγκρίνετε'
+                    ? 'Συνδεθείτε για επιβεβαίωση'
                     : endorsed
-                    ? 'Κάντε κλικ για αφαίρεση έγκρισης'
-                    : 'Κάντε κλικ για έγκριση'
+                    ? 'Κάντε κλικ για αφαίρεση'
+                    : TOPIC_HELPERS[topic]
                 }
-                className={`inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full text-sm font-medium border transition-all ${
+                className={`flex min-h-[64px] items-start justify-between gap-3 rounded-lg border px-3 py-2 text-left transition-colors ${
                   endorsed
-                    ? 'bg-blue-600 text-white border-blue-600'
+                    ? 'bg-blue-50 text-blue-800 border-blue-300'
                     : 'bg-white text-gray-700 border-gray-300'
-                } ${canToggle && !isToggling ? 'hover:border-blue-400 cursor-pointer' : 'cursor-default'} ${
+                } ${canToggle && !isToggling ? 'hover:border-blue-400 hover:bg-blue-50 cursor-pointer' : 'cursor-default'} ${
                   isToggling ? 'opacity-60' : ''
                 }`}
               >
-                <span>{TOPIC_LABELS[topic]}</span>
-                {count > 0 && (
-                  <span
-                    className={`text-xs font-bold rounded-full px-1.5 py-0.5 ${
-                      endorsed ? 'bg-blue-500 text-white' : 'bg-gray-100 text-gray-600'
-                    }`}
-                  >
-                    {count}
-                  </span>
-                )}
+                <span>
+                  <span className="block text-sm font-semibold">{TOPIC_LABELS[topic]}</span>
+                  <span className="mt-1 block text-xs leading-5 text-gray-500">{TOPIC_HELPERS[topic]}</span>
+                </span>
+                <span
+                  className={`shrink-0 rounded-full px-2 py-0.5 text-xs font-bold ${
+                    endorsed ? 'bg-blue-600 text-white' : 'bg-gray-100 text-gray-600'
+                  }`}
+                >
+                  {count}
+                </span>
               </button>
             );
           })}
@@ -167,13 +162,13 @@ export default function EndorsementPanel({ targetUserId }) {
           <LoginLink className="text-blue-600 hover:underline">
             Συνδεθείτε
           </LoginLink>{' '}
-          για να εγκρίνετε αυτόν τον χρήστη για ένα θέμα.
+          για να επιβεβαιώσετε μια πραγματική σχέση με αυτόν τον χρήστη.
         </p>
       )}
 
       {!authLoading && isAuthenticated && !isSelf && (
         <p className="mt-3 text-xs text-gray-500">
-          Κάντε κλικ σε ένα θέμα για να εγκρίνετε ή να αφαιρέσετε την έγκρισή σας.
+          Επιλέξτε μόνο όσα γνωρίζετε προσωπικά. Οι επιβεβαιώσεις είναι για πραγματικές σχέσεις, όχι για πολιτική συμφωνία.
         </p>
       )}
     </div>

--- a/src/controllers/endorsementController.js
+++ b/src/controllers/endorsementController.js
@@ -173,7 +173,7 @@ const endorsementController = {
 
   /**
    * GET /api/endorsements/status?userId=...
-   * Returns which topics the current user has endorsed the target user for.
+   * Returns public counts plus the current user's endorsed topics when authenticated.
    */
   status: async (req, res) => {
     try {
@@ -183,12 +183,14 @@ const endorsementController = {
       }
       const endorsedId = idResult.value;
 
-      const endorsements = await Endorsement.findAll({
-        where: { endorserId: req.user.id, endorsedId },
-        attributes: ['topic']
-      });
-
-      const endorsedTopics = endorsements.map((e) => e.topic);
+      let endorsedTopics = [];
+      if (req.user?.id) {
+        const endorsements = await Endorsement.findAll({
+          where: { endorserId: req.user.id, endorsedId },
+          attributes: ['topic']
+        });
+        endorsedTopics = endorsements.map((e) => e.topic);
+      }
 
       // Also return per-topic counts for the target user
       const topicCounts = await Endorsement.findAll({

--- a/src/migrations/20260625140500-add-relationship-endorsement-types.js
+++ b/src/migrations/20260625140500-add-relationship-endorsement-types.js
@@ -1,0 +1,26 @@
+'use strict';
+
+const RELATIONSHIP_ENDORSEMENT_TYPES = [
+  'Real Profile',
+  'Knows Personally',
+  'Worked Together',
+  'Local Connection'
+];
+
+module.exports = {
+  up: async (queryInterface) => {
+    const dialect = queryInterface.sequelize.getDialect();
+    if (dialect !== 'postgres') return;
+
+    for (const type of RELATIONSHIP_ENDORSEMENT_TYPES) {
+      await queryInterface.sequelize.query(
+        `ALTER TYPE "enum_Endorsements_topic" ADD VALUE IF NOT EXISTS '${type}';`
+      );
+    }
+  },
+
+  down: async () => {
+    // PostgreSQL does not support removing enum values safely without rebuilding the type.
+    // Leaving these values in place is harmless and preserves existing endorsements.
+  }
+};

--- a/src/models/Endorsement.js
+++ b/src/models/Endorsement.js
@@ -2,12 +2,10 @@ const { DataTypes } = require('sequelize');
 const sequelize = require('../config/database');
 
 const ENDORSEMENT_TOPICS = [
-  'Education',
-  'Economy',
-  'Health',
-  'Environment',
-  'Local Governance',
-  'Technology'
+  'Real Profile',
+  'Knows Personally',
+  'Worked Together',
+  'Local Connection'
 ];
 
 const Endorsement = sequelize.define('Endorsement', {

--- a/src/routes/endorsementRoutes.js
+++ b/src/routes/endorsementRoutes.js
@@ -2,15 +2,16 @@ const express = require('express');
 const router = express.Router();
 const endorsementController = require('../controllers/endorsementController');
 const authMiddleware = require('../middleware/auth');
+const optionalAuthMiddleware = require('../middleware/optionalAuth');
 const csrfProtection = require('../middleware/csrfProtection');
 const { apiLimiter } = require('../middleware/rateLimiter');
 
 // Public routes
 router.get('/topics', apiLimiter, endorsementController.topics);
 router.get('/leaderboard', apiLimiter, endorsementController.leaderboard);
+router.get('/status', apiLimiter, optionalAuthMiddleware, endorsementController.status);
 
 // Authenticated routes
-router.get('/status', apiLimiter, authMiddleware, endorsementController.status);
 router.post('/', apiLimiter, authMiddleware, csrfProtection, endorsementController.create);
 router.delete('/', apiLimiter, authMiddleware, csrfProtection, endorsementController.remove);
 


### PR DESCRIPTION
## Summary
- Replace topic/expertise endorsement choices with four relationship-based endorsements: Real Profile, Knows Personally, Worked Together, Local Connection
- Add a migration for the new Postgres enum values
- Make endorsement status public for counts while preserving authenticated user-specific selections
- Update the profile endorsement panel, worthy-citizens leaderboard filters, and endorsement tests

## Design direction
- Keep endorsements minimal and factual
- Avoid popularity-style labels such as trustworthy, smart, or good person
- Use endorsements for real-world relationship signals, not political agreement
- Keep the profile UI compact and avoid duplicate badge/count sections

## Testing
- Not run locally; change made via GitHub connector.