### PR TITLE
Show location user counts to guests

### DIFF
--- a/src/controllers/locationController.js
+++ b/src/controllers/locationController.js
@@ -150,11 +150,20 @@ exports.getLocationEntities = async (req, res) => {
       ...(result.error !== undefined && { error: result.error })
     });
   }
+
+  let usersCount = result.usersCount;
+  if (!req.user) {
+    const publicStats = await locationService.getLocation(req.params.id);
+    if (publicStats.success) {
+      usersCount = publicStats.stats?.userCount ?? usersCount;
+    }
+  }
+
   return res.json({
     success: true,
     articles: result.articles,
     users: result.users,
-    usersCount: result.usersCount,
+    usersCount,
     unclaimed: result.unclaimed,
     unclaimedCount: result.unclaimedCount,
     polls: result.polls


### PR DESCRIPTION
## Summary
- Keep location user lists hidden from unregistered visitors
- Use public location stats so guests still see the aggregate user count
- Preserve the existing authenticated behavior for seeing user rows

## Design/privacy direction
- Show useful aggregate civic signals publicly
- Do not expose individual user profiles to guests through location pages
- Keep the change minimal and avoid duplicate UI/count sections

## Testing
- Not run locally; change made via GitHub connector.