### PR TITLE
[codex] Harden search input handling

### DIFF
--- a/__tests__/validators-escape-like.test.js
+++ b/__tests__/validators-escape-like.test.js
@@ -1,0 +1,11 @@
+const { escapeLikePattern } = require('../src/utils/validators');
+
+describe('escapeLikePattern', () => {
+  it('escapes SQL LIKE wildcards and the escape character', () => {
+    expect(escapeLikePattern('100%_done\\today')).toBe('100\\%\\_done\\\\today');
+  });
+
+  it('coerces non-string values before escaping', () => {
+    expect(escapeLikePattern(123)).toBe('123');
+  });
+});

--- a/src/controllers/reportController.js
+++ b/src/controllers/reportController.js
@@ -4,6 +4,13 @@ const { Report, User } = require('../models');
 
 const CONTENT_TYPES = ['article', 'person', 'poll', 'comment', 'candidate', 'user'];
 const CATEGORIES = ['misinformation', 'harassment', 'spam', 'privacy_violation', 'impersonation', 'inappropriate_content', 'other'];
+const REPORT_STATUSES = ['pending', 'reviewed', 'dismissed', 'actioned'];
+
+function parseListPagination(query = {}) {
+  const page = Math.max(1, parseInt(query.page, 10) || 1);
+  const limit = Math.min(100, Math.max(1, parseInt(query.limit, 10) || 20));
+  return { page, limit, offset: (page - 1) * limit };
+}
 
 const reportController = {
   // POST /api/reports — public (optionalAuth)
@@ -72,12 +79,22 @@ const reportController = {
 
   // GET /api/reports — admin/moderator
   getReports: async (req, res) => {
-    const { page = 1, limit = 20, status, contentType } = req.query;
-    const offset = (parseInt(page) - 1) * parseInt(limit);
+    const { status, contentType } = req.query;
+    const { page, limit, offset } = parseListPagination(req.query);
 
     const where = {};
-    if (status) where.status = status;
-    if (contentType) where.contentType = contentType;
+    if (status) {
+      if (!REPORT_STATUSES.includes(status)) {
+        return res.status(400).json({ success: false, message: 'Invalid report status.' });
+      }
+      where.status = status;
+    }
+    if (contentType) {
+      if (!CONTENT_TYPES.includes(contentType)) {
+        return res.status(400).json({ success: false, message: 'Invalid contentType.' });
+      }
+      where.contentType = contentType;
+    }
 
     const { count, rows } = await Report.findAndCountAll({
       where,
@@ -85,7 +102,7 @@ const reportController = {
         { model: User, as: 'reporter', attributes: ['id', 'username'], required: false },
         { model: User, as: 'reviewer', attributes: ['id', 'username'], required: false }
       ],
-      limit: parseInt(limit),
+      limit,
       offset,
       order: [['createdAt', 'DESC']]
     });
@@ -96,8 +113,9 @@ const reportController = {
         reports: rows,
         pagination: {
           total: count,
-          page: parseInt(page),
-          totalPages: Math.ceil(count / parseInt(limit))
+          page,
+          totalPages: Math.ceil(count / limit),
+          itemsPerPage: limit
         }
       }
     });

--- a/src/controllers/tagController.js
+++ b/src/controllers/tagController.js
@@ -1,5 +1,6 @@
 const { Tag, TaggableItem, sequelize } = require('../models');
 const { Op } = require('sequelize');
+const { escapeLikePattern } = require('../utils/validators');
 
 const VALID_ENTITY_TYPES = ['article', 'poll', 'suggestion'];
 
@@ -25,10 +26,11 @@ const getSuggestions = async (req, res) => {
     if (q && typeof q === 'string') {
       const prefix = q.trim().toLowerCase();
       if (prefix) {
+        const escapedPrefix = escapeLikePattern(prefix);
         const dialect = sequelize.getDialect();
         tagWhere.name = dialect === 'postgres'
-          ? { [Op.iLike]: `${prefix}%` }
-          : { [Op.like]: `${prefix}%` };
+          ? { [Op.iLike]: `${escapedPrefix}%` }
+          : { [Op.like]: `${escapedPrefix}%` };
       }
     }
 

--- a/src/services/organizationService.js
+++ b/src/services/organizationService.js
@@ -4,6 +4,7 @@ const path = require('path');
 const dbConfig = require('../config/database');
 const { Op } = require('sequelize');
 const { Organization, OrganizationMember, OrganizationAnalytics, Poll, Suggestion } = require('../models');
+const { escapeLikePattern } = require('../utils/validators');
 
 const { types: ORGANIZATION_TYPES } = require(path.resolve(__dirname, '../../config/organizationTypes.json'));
 
@@ -46,7 +47,7 @@ function buildSearchWhere(search) {
   if (!cleanSearch) return {};
 
   const likeOp = dbConfig.getDialect() === 'postgres' ? Op.iLike : Op.like;
-  const escaped = cleanSearch.replace(/[%_\\]/g, '\\$&');
+  const escaped = escapeLikePattern(cleanSearch);
 
   return {
     [Op.or]: [

--- a/src/utils/validators.js
+++ b/src/utils/validators.js
@@ -241,6 +241,13 @@ const normalizeInteger = (value, fieldLabel, minValue, maxValue) => {
   return { value: numValue };
 };
 
+/**
+ * Escape special characters in SQL LIKE patterns.
+ * @param {*} value - The raw search text
+ * @returns {string}
+ */
+const escapeLikePattern = (value) => String(value).replace(/[\\%_]/g, '\\$&');
+
 module.exports = {
   normalizeRequiredText,
   normalizeOptionalText,
@@ -251,4 +258,5 @@ module.exports = {
   normalizeEnum,
   normalizeUrl,
   normalizeInteger,
+  escapeLikePattern,
 };


### PR DESCRIPTION
## Summary

- Add a shared `escapeLikePattern` utility for SQL `LIKE`/`ILIKE` search patterns.
- Use the helper in tag suggestions and organization search so `%`, `_`, and backslash are treated as literal search text.
- Clamp report-list pagination and reject invalid report status/content-type filters before querying.
- Add a focused unit test for the LIKE escaping helper.

## Why

The SQL injection spot check did not find direct interpolation into runtime SQL, but a few search and admin-list surfaces could be hardened. This keeps behavior predictable and reduces the chance that future search code reintroduces wildcard or pagination edge cases.

## Validation

- Not run locally: this environment has neither `git` nor `gh` on PATH, and I created the branch through the GitHub connector.
- Added `__tests__/validators-escape-like.test.js` for the new helper.

## Follow-up

Article and suggestion free-text search still use Sequelize-bound values, but they can be moved onto the same helper in a follow-up PR if you want this pattern applied everywhere.