### PR TITLE
[codex] Add modular media library backend

### DIFF
--- a/lib/api/index.js
+++ b/lib/api/index.js
@@ -23,6 +23,7 @@ export { endorsementAPI } from './endorsements.js';
 export { suggestionAPI } from './suggestions.js';
 export { linkPreviewAPI } from './linkPreview.js';
 export { newsletterAPI } from './newsletter.js';
+export { mediaAPI } from './media.js';
 export { personAPI } from './persons.js';
 export { personRemovalRequestAPI } from './personRemovalRequests.js';
 export { reportAPI } from './reports.js';

--- a/lib/api/media.js
+++ b/lib/api/media.js
@@ -1,0 +1,24 @@
+import { apiRequest } from './client.js';
+import { buildQueryEndpoint } from '../utils/queryString.js';
+
+export const mediaAPI = {
+  list: async (params = {}) => {
+    return apiRequest(buildQueryEndpoint('/api/media', params));
+  },
+
+  uploadArticleImage: async (file, fields = {}) => {
+    const formData = new FormData();
+    formData.append('image', file);
+
+    Object.entries(fields).forEach(([key, value]) => {
+      if (value !== undefined && value !== null && value !== '') {
+        formData.append(key, value);
+      }
+    });
+
+    return apiRequest('/api/media/articles/images', {
+      method: 'POST',
+      body: formData,
+    });
+  },
+};

--- a/src/controllers/mediaController.js
+++ b/src/controllers/mediaController.js
@@ -1,0 +1,53 @@
+'use strict';
+
+const mediaService = require('../services/mediaService');
+
+function handleMulterError(error, res) {
+  if (!error) return false;
+
+  if (error.code === 'LIMIT_FILE_SIZE') {
+    res.status(400).json({ success: false, message: 'Image must be 8MB or smaller.' });
+    return true;
+  }
+
+  res.status(400).json({ success: false, message: error.message || 'Invalid upload.' });
+  return true;
+}
+
+const mediaController = {
+  listMedia: async (req, res) => {
+    try {
+      const result = await mediaService.listMediaAssets(req.query, req.user);
+      if (!result.success) {
+        return res.status(result.status).json({ success: false, message: result.message });
+      }
+
+      return res.status(200).json({
+        success: true,
+        media: result.media,
+        pagination: result.pagination,
+      });
+    } catch (error) {
+      console.error('mediaController.listMedia error:', error);
+      return res.status(500).json({ success: false, message: 'Failed to fetch media.' });
+    }
+  },
+
+  uploadArticleImage: async (req, res) => {
+    try {
+      if (handleMulterError(req.fileValidationError, res)) return;
+
+      const result = await mediaService.uploadArticleImage(req.file, req.user, req.body || {});
+      if (!result.success) {
+        return res.status(result.status).json({ success: false, message: result.message });
+      }
+
+      return res.status(201).json({ success: true, media: result.media });
+    } catch (error) {
+      console.error('mediaController.uploadArticleImage error:', error);
+      return res.status(500).json({ success: false, message: 'Failed to upload image.' });
+    }
+  },
+};
+
+module.exports = mediaController;

--- a/src/migrations/20260626090000-create-media-assets.js
+++ b/src/migrations/20260626090000-create-media-assets.js
@@ -1,0 +1,105 @@
+'use strict';
+
+const MEDIA_USAGE_TYPES = ['shared', 'article_banner', 'article_body'];
+const MEDIA_STATUSES = ['active', 'archived'];
+
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    const dialect = queryInterface.sequelize.getDialect();
+    const tables = await queryInterface.showAllTables();
+    const tableNames = tables.map((table) => (typeof table === 'string' ? table : table.tableName || table.name));
+
+    if (tableNames.includes('MediaAssets')) {
+      return;
+    }
+
+    await queryInterface.createTable('MediaAssets', {
+      id: {
+        type: Sequelize.INTEGER,
+        primaryKey: true,
+        autoIncrement: true,
+        allowNull: false,
+      },
+      storageProvider: {
+        type: Sequelize.STRING(32),
+        allowNull: false,
+        defaultValue: 'local',
+      },
+      storageKey: {
+        type: Sequelize.STRING(500),
+        allowNull: false,
+        unique: true,
+      },
+      url: {
+        type: Sequelize.STRING(500),
+        allowNull: false,
+      },
+      originalName: {
+        type: Sequelize.STRING(255),
+        allowNull: true,
+      },
+      mimeType: {
+        type: Sequelize.STRING(100),
+        allowNull: false,
+      },
+      size: {
+        type: Sequelize.INTEGER,
+        allowNull: false,
+      },
+      width: {
+        type: Sequelize.INTEGER,
+        allowNull: true,
+      },
+      height: {
+        type: Sequelize.INTEGER,
+        allowNull: true,
+      },
+      usageType: {
+        type: dialect === 'postgres' ? Sequelize.ENUM(...MEDIA_USAGE_TYPES) : Sequelize.STRING(32),
+        allowNull: false,
+        defaultValue: 'shared',
+      },
+      status: {
+        type: dialect === 'postgres' ? Sequelize.ENUM(...MEDIA_STATUSES) : Sequelize.STRING(32),
+        allowNull: false,
+        defaultValue: 'active',
+      },
+      altText: {
+        type: Sequelize.STRING(255),
+        allowNull: true,
+      },
+      credit: {
+        type: Sequelize.STRING(255),
+        allowNull: true,
+      },
+      uploadedByUserId: {
+        type: Sequelize.INTEGER,
+        allowNull: false,
+        references: { model: 'Users', key: 'id' },
+        onDelete: 'CASCADE',
+      },
+      createdAt: {
+        type: Sequelize.DATE,
+        allowNull: false,
+      },
+      updatedAt: {
+        type: Sequelize.DATE,
+        allowNull: false,
+      },
+    });
+
+    await queryInterface.addIndex('MediaAssets', ['storageProvider']);
+    await queryInterface.addIndex('MediaAssets', ['usageType']);
+    await queryInterface.addIndex('MediaAssets', ['status']);
+    await queryInterface.addIndex('MediaAssets', ['uploadedByUserId']);
+  },
+
+  async down(queryInterface) {
+    await queryInterface.dropTable('MediaAssets').catch(() => {});
+
+    if (queryInterface.sequelize.getDialect() === 'postgres') {
+      await queryInterface.sequelize.query('DROP TYPE IF EXISTS "enum_MediaAssets_usageType";').catch(() => {});
+      await queryInterface.sequelize.query('DROP TYPE IF EXISTS "enum_MediaAssets_status";').catch(() => {});
+    }
+  },
+};

--- a/src/models/MediaAsset.js
+++ b/src/models/MediaAsset.js
@@ -1,0 +1,88 @@
+const { DataTypes } = require('sequelize');
+const sequelize = require('../config/database');
+
+const MEDIA_USAGE_TYPES = ['shared', 'article_banner', 'article_body'];
+const MEDIA_STATUSES = ['active', 'archived'];
+
+const MediaAsset = sequelize.define('MediaAsset', {
+  id: {
+    type: DataTypes.INTEGER,
+    primaryKey: true,
+    autoIncrement: true,
+  },
+  storageProvider: {
+    type: DataTypes.STRING(32),
+    allowNull: false,
+    defaultValue: 'local',
+  },
+  storageKey: {
+    type: DataTypes.STRING(500),
+    allowNull: false,
+    unique: true,
+  },
+  url: {
+    type: DataTypes.STRING(500),
+    allowNull: false,
+  },
+  originalName: {
+    type: DataTypes.STRING(255),
+    allowNull: true,
+  },
+  mimeType: {
+    type: DataTypes.STRING(100),
+    allowNull: false,
+  },
+  size: {
+    type: DataTypes.INTEGER,
+    allowNull: false,
+  },
+  width: {
+    type: DataTypes.INTEGER,
+    allowNull: true,
+  },
+  height: {
+    type: DataTypes.INTEGER,
+    allowNull: true,
+  },
+  usageType: {
+    type: DataTypes.ENUM(...MEDIA_USAGE_TYPES),
+    allowNull: false,
+    defaultValue: 'shared',
+  },
+  status: {
+    type: DataTypes.ENUM(...MEDIA_STATUSES),
+    allowNull: false,
+    defaultValue: 'active',
+  },
+  altText: {
+    type: DataTypes.STRING(255),
+    allowNull: true,
+  },
+  credit: {
+    type: DataTypes.STRING(255),
+    allowNull: true,
+  },
+  uploadedByUserId: {
+    type: DataTypes.INTEGER,
+    allowNull: false,
+    references: {
+      model: 'Users',
+      key: 'id',
+    },
+    onDelete: 'CASCADE',
+  },
+}, {
+  tableName: 'MediaAssets',
+  timestamps: true,
+  indexes: [
+    { fields: ['storageProvider'] },
+    { fields: ['usageType'] },
+    { fields: ['status'] },
+    { fields: ['uploadedByUserId'] },
+  ],
+});
+
+MediaAsset.MEDIA_USAGE_TYPES = MEDIA_USAGE_TYPES;
+MediaAsset.MEDIA_STATUSES = MEDIA_STATUSES;
+
+module.exports = MediaAsset;

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -32,6 +32,7 @@ const officialPostsRoutes = require('./officialPostsRoutes');
 const newsletterRoutes = require('./newsletterRoutes');
 const pushRoutes = require('./pushRoutes');
 const politicalAffiliationRoutes = require('./politicalAffiliationRoutes');
+const mediaRoutes = require('./mediaRoutes');
 
 const geoRoutes = express.Router();
 geoRoutes.use(geoAccessPublicRoutes);
@@ -72,6 +73,7 @@ const routes = [
   { prefix: '/api/official-posts', router: officialPostsRoutes },
   { prefix: '/api/newsletter', router: newsletterRoutes },
   { prefix: '/api/push', router: pushRoutes },
+  { prefix: '/api/media', router: mediaRoutes },
   { prefix: '/api/users/:id/political-affiliations', router: politicalAffiliationRoutes },
 ];
 

--- a/src/routes/mediaRoutes.js
+++ b/src/routes/mediaRoutes.js
@@ -1,0 +1,34 @@
+const express = require('express');
+const multer = require('multer');
+const mediaController = require('../controllers/mediaController');
+const authMiddleware = require('../middleware/auth');
+const csrfProtection = require('../middleware/csrfProtection');
+const { apiLimiter, uploadLimiter } = require('../middleware/rateLimiter');
+
+const router = express.Router();
+
+const upload = multer({
+  storage: multer.memoryStorage(),
+  limits: { fileSize: 8 * 1024 * 1024, files: 1 },
+  fileFilter: (req, file, cb) => {
+    if (['image/jpeg', 'image/png', 'image/webp'].includes(file.mimetype)) {
+      return cb(null, true);
+    }
+    return cb(new Error('Only JPEG, PNG, and WebP images are supported.'));
+  },
+});
+
+const handleUpload = (req, res, next) => {
+  upload.single('image')(req, res, (error) => {
+    if (!error) return next();
+    if (error.code === 'LIMIT_FILE_SIZE') {
+      return res.status(400).json({ success: false, message: 'Image must be 8MB or smaller.' });
+    }
+    return res.status(400).json({ success: false, message: error.message || 'Invalid upload.' });
+  });
+};
+
+router.get('/', authMiddleware, apiLimiter, mediaController.listMedia);
+router.post('/articles/images', authMiddleware, uploadLimiter, csrfProtection, handleUpload, mediaController.uploadArticleImage);
+
+module.exports = router;

--- a/src/services/mediaService.js
+++ b/src/services/mediaService.js
@@ -1,0 +1,178 @@
+'use strict';
+
+const path = require('path');
+const crypto = require('crypto');
+const sharp = require('sharp');
+const { MediaAsset, User } = require('../models');
+const { getStorageAdapter } = require('./storage');
+
+const ALLOWED_IMAGE_MIME_TYPES = new Set(['image/jpeg', 'image/png', 'image/webp']);
+const UPLOAD_ROLES = new Set(['admin', 'moderator', 'editor']);
+const MAX_IMAGE_BYTES = 8 * 1024 * 1024;
+const OUTPUT_MIME_TYPE = 'image/webp';
+const OUTPUT_EXTENSION = 'webp';
+const MEDIA_USAGE_TYPES = MediaAsset.MEDIA_USAGE_TYPES || ['shared', 'article_banner', 'article_body'];
+
+function canManageMedia(user) {
+  return !!user && UPLOAD_ROLES.has(user.role);
+}
+
+function normalizeOptionalText(value, maxLength) {
+  if (value === undefined || value === null) return null;
+  const trimmed = String(value).trim();
+  if (!trimmed) return null;
+  return trimmed.slice(0, maxLength);
+}
+
+function normalizeUsageType(value, fallback = 'shared') {
+  if (!value) return fallback;
+  return MEDIA_USAGE_TYPES.includes(value) ? value : fallback;
+}
+
+function buildStorageKey(userId) {
+  const now = new Date();
+  const year = String(now.getUTCFullYear());
+  const month = String(now.getUTCMonth() + 1).padStart(2, '0');
+  const id = crypto.randomUUID();
+  return path.posix.join('media', year, month, `${userId}-${id}.${OUTPUT_EXTENSION}`);
+}
+
+function serializeMediaAsset(asset) {
+  const data = asset?.toJSON ? asset.toJSON() : asset;
+  if (!data) return null;
+
+  return {
+    id: data.id,
+    url: data.url,
+    storageProvider: data.storageProvider,
+    storageKey: data.storageKey,
+    originalName: data.originalName,
+    mimeType: data.mimeType,
+    size: data.size,
+    width: data.width,
+    height: data.height,
+    usageType: data.usageType,
+    status: data.status,
+    altText: data.altText,
+    credit: data.credit,
+    uploadedByUserId: data.uploadedByUserId,
+    uploadedBy: data.uploadedBy || null,
+    createdAt: data.createdAt,
+    updatedAt: data.updatedAt,
+  };
+}
+
+async function processImage(file) {
+  if (!file) {
+    return { success: false, status: 400, message: 'Image file is required.' };
+  }
+
+  if (!ALLOWED_IMAGE_MIME_TYPES.has(file.mimetype)) {
+    return { success: false, status: 400, message: 'Only JPEG, PNG, and WebP images are supported.' };
+  }
+
+  if (!Buffer.isBuffer(file.buffer) || file.buffer.length === 0) {
+    return { success: false, status: 400, message: 'Uploaded image is empty.' };
+  }
+
+  if (file.size > MAX_IMAGE_BYTES || file.buffer.length > MAX_IMAGE_BYTES) {
+    return { success: false, status: 400, message: 'Image must be 8MB or smaller.' };
+  }
+
+  try {
+    const output = await sharp(file.buffer, { limitInputPixels: 24000000 })
+      .rotate()
+      .resize({ width: 1600, height: 1600, fit: 'inside', withoutEnlargement: true })
+      .webp({ quality: 82 })
+      .toBuffer({ resolveWithObject: true });
+
+    return {
+      success: true,
+      buffer: output.data,
+      width: output.info.width,
+      height: output.info.height,
+      size: output.data.length,
+      mimeType: OUTPUT_MIME_TYPE,
+    };
+  } catch (error) {
+    console.error('mediaService.processImage error:', error);
+    return { success: false, status: 400, message: 'Image could not be processed.' };
+  }
+}
+
+async function uploadArticleImage(file, user, metadata = {}) {
+  if (!canManageMedia(user)) {
+    return { success: false, status: 403, message: 'You do not have permission to upload media.' };
+  }
+
+  const processed = await processImage(file);
+  if (!processed.success) return processed;
+
+  const usageType = normalizeUsageType(metadata.usageType, 'article_banner');
+  const storageKey = buildStorageKey(user.id);
+  const storage = getStorageAdapter();
+  const stored = await storage.saveFile({ buffer: processed.buffer, storageKey });
+
+  const asset = await MediaAsset.create({
+    storageProvider: stored.storageProvider,
+    storageKey: stored.storageKey,
+    url: stored.url,
+    originalName: normalizeOptionalText(file.originalname, 255),
+    mimeType: processed.mimeType,
+    size: processed.size,
+    width: processed.width,
+    height: processed.height,
+    usageType,
+    status: 'active',
+    altText: normalizeOptionalText(metadata.altText, 255),
+    credit: normalizeOptionalText(metadata.credit, 255),
+    uploadedByUserId: user.id,
+  });
+
+  return { success: true, media: serializeMediaAsset(asset) };
+}
+
+async function listMediaAssets(query = {}, user = null) {
+  if (!canManageMedia(user)) {
+    return { success: false, status: 403, message: 'You do not have permission to view media.' };
+  }
+
+  const page = Math.max(1, parseInt(query.page, 10) || 1);
+  const limit = Math.min(60, Math.max(1, parseInt(query.limit, 10) || 24));
+  const where = { status: 'active' };
+
+  if (query.usageType && MEDIA_USAGE_TYPES.includes(query.usageType)) {
+    where.usageType = query.usageType;
+  }
+
+  const { count, rows } = await MediaAsset.findAndCountAll({
+    where,
+    include: [{
+      model: User,
+      as: 'uploadedBy',
+      attributes: ['id', 'username', 'avatar', 'avatarColor'],
+      required: false,
+    }],
+    order: [['createdAt', 'DESC'], ['id', 'DESC']],
+    limit,
+    offset: (page - 1) * limit,
+  });
+
+  return {
+    success: true,
+    media: rows.map(serializeMediaAsset),
+    pagination: {
+      total: count,
+      page,
+      limit,
+      totalPages: Math.ceil(count / limit),
+    },
+  };
+}
+
+module.exports = {
+  canManageMedia,
+  uploadArticleImage,
+  listMediaAssets,
+  serializeMediaAsset,
+};

--- a/src/services/mediaService.js
+++ b/src/services/mediaService.js
@@ -3,8 +3,13 @@
 const path = require('path');
 const crypto = require('crypto');
 const sharp = require('sharp');
-const { MediaAsset, User } = require('../models');
+const MediaAsset = require('../models/MediaAsset');
+const { User } = require('../models');
 const { getStorageAdapter } = require('./storage');
+
+if (!MediaAsset.associations.uploadedBy) {
+  MediaAsset.belongsTo(User, { foreignKey: 'uploadedByUserId', as: 'uploadedBy' });
+}
 
 const ALLOWED_IMAGE_MIME_TYPES = new Set(['image/jpeg', 'image/png', 'image/webp']);
 const UPLOAD_ROLES = new Set(['admin', 'moderator', 'editor']);

--- a/src/services/storage/index.js
+++ b/src/services/storage/index.js
@@ -1,0 +1,15 @@
+'use strict';
+
+const localMediaStorageAdapter = require('./localMediaStorageAdapter');
+
+function getStorageAdapter(provider = process.env.MEDIA_STORAGE_PROVIDER || 'local') {
+  if (provider === 'local') {
+    return localMediaStorageAdapter;
+  }
+
+  throw new Error(`Unsupported media storage provider: ${provider}`);
+}
+
+module.exports = {
+  getStorageAdapter,
+};

--- a/src/services/storage/localMediaStorageAdapter.js
+++ b/src/services/storage/localMediaStorageAdapter.js
@@ -1,0 +1,48 @@
+'use strict';
+
+const fs = require('fs/promises');
+const path = require('path');
+
+const uploadRoot = process.env.MEDIA_UPLOAD_ROOT || path.join(__dirname, '..', '..', '..', 'uploads');
+
+function resolveStoragePath(storageKey) {
+  const normalizedKey = String(storageKey || '').replace(/\\/g, '/').replace(/^\/+/, '');
+  const absolutePath = path.resolve(uploadRoot, normalizedKey);
+  const absoluteRoot = path.resolve(uploadRoot);
+
+  if (absolutePath !== absoluteRoot && !absolutePath.startsWith(`${absoluteRoot}${path.sep}`)) {
+    throw new Error('Invalid media storage key.');
+  }
+
+  return { normalizedKey, absolutePath };
+}
+
+async function saveFile({ buffer, storageKey }) {
+  if (!Buffer.isBuffer(buffer)) {
+    throw new Error('Storage adapter requires a Buffer.');
+  }
+
+  const { normalizedKey, absolutePath } = resolveStoragePath(storageKey);
+  await fs.mkdir(path.dirname(absolutePath), { recursive: true });
+  await fs.writeFile(absolutePath, buffer);
+
+  return {
+    storageProvider: 'local',
+    storageKey: normalizedKey,
+    url: `/uploads/${normalizedKey}`,
+  };
+}
+
+async function deleteFile(storageKey) {
+  const { absolutePath } = resolveStoragePath(storageKey);
+  await fs.unlink(absolutePath).catch((error) => {
+    if (error && error.code !== 'ENOENT') {
+      throw error;
+    }
+  });
+}
+
+module.exports = {
+  saveFile,
+  deleteFile,
+};


### PR DESCRIPTION
## Summary

- Add a `MediaAsset` model and migration for shared media metadata.
- Keep a public `url` field so existing article fields like `bannerImageUrl` can keep using normal URLs without knowing about storage internals.
- Add `storageProvider` and `storageKey` fields plus a local storage adapter so future nodeworker/object-storage adapters can use the same service boundary.
- Add `/api/media` listing and `/api/media/articles/images` upload endpoints for `admin`, `moderator`, and `editor` users.
- Process uploads through `sharp`: JPEG/PNG/WebP only, max 8MB, rotate/resize, output WebP, strip metadata by default.
- Add a small frontend `mediaAPI` wrapper for future article-form integration.

## Why

Article images currently rely on manual URLs. This introduces a controlled shared media library foundation without tying article code to local disk storage. The app can store files locally now and later move the physical storage to nodeworkers while preserving the same `MediaAsset.url` contract.

## Notes

- The upload form field name is `image`.
- Local files are stored below `/uploads/media/...` and served by the existing `/uploads` static route.
- This PR intentionally does not add the article form picker yet; it creates the reusable backend/API layer first to avoid duplicating upload logic in the UI.

## Validation

- Not run locally: this environment does not have `git`/`gh` available, and the branch was created through the GitHub connector.
- Diff checked with GitHub compare before opening the PR.