### PR TITLE
[codex] Add article image upload controls

### DIFF
--- a/__tests__/article-form.test.js
+++ b/__tests__/article-form.test.js
@@ -43,8 +43,17 @@ const mockLocationAPI = {
   }))
 };
 
+const mockMediaAPI = {
+  list: jest.fn(() => Promise.resolve({ success: true, media: [] })),
+  uploadArticleImage: jest.fn(() => Promise.resolve({
+    success: true,
+    media: { id: 1, url: '/uploads/media/test.webp' },
+  })),
+};
+
 jest.mock('@/lib/api', () => ({
   locationAPI: mockLocationAPI,
+  mediaAPI: mockMediaAPI,
   tagAPI: {
     getSuggestions: jest.fn(() => Promise.resolve({ tags: [] })),
   },
@@ -382,6 +391,45 @@ describe('ArticleForm Component', () => {
     const approvedCheckbox = container.querySelector('input[name="approved"]');
     expect(approvedCheckbox).toBeTruthy();
     expect(approvedCheckbox.type).toBe('checkbox');
+
+    await act(async () => { root.unmount(); });
+  });
+
+  test('banner image upload controls are shown for article media managers', async () => {
+    mockUseAuth.mockReturnValue({ user: { id: 3, role: 'editor' } });
+    const ArticleForm = require('../components/articles/ArticleForm').default;
+
+    const { container, root } = await renderComponent(ArticleForm, {
+      article: null,
+      onSubmit: jest.fn(),
+      onCancel: jest.fn(),
+      isSubmitting: false,
+      submitError: ''
+    });
+
+    expect(container.textContent).toContain('Upload photo');
+    expect(container.textContent).toContain('Refresh library');
+    expect(container.querySelector('input[type="file"]')).toBeTruthy();
+    expect(mockMediaAPI.list).toHaveBeenCalledWith({ usageType: 'article_banner', limit: 12 });
+
+    await act(async () => { root.unmount(); });
+  });
+
+  test('banner image upload controls are hidden for regular viewers', async () => {
+    mockUseAuth.mockReturnValue({ user: { id: 4, role: 'viewer' } });
+    const ArticleForm = require('../components/articles/ArticleForm').default;
+
+    const { container, root } = await renderComponent(ArticleForm, {
+      article: null,
+      onSubmit: jest.fn(),
+      onCancel: jest.fn(),
+      isSubmitting: false,
+      submitError: ''
+    });
+
+    expect(container.textContent).not.toContain('Upload photo');
+    expect(container.querySelector('input[type="file"]')).toBeNull();
+    expect(mockMediaAPI.list).not.toHaveBeenCalled();
 
     await act(async () => { root.unmount(); });
   });

--- a/components/articles/ArticleBannerImageField.js
+++ b/components/articles/ArticleBannerImageField.js
@@ -1,0 +1,148 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+import FormInput from '@/components/ui/FormInput';
+import AlertMessage from '@/components/ui/AlertMessage';
+import { mediaAPI } from '@/lib/api';
+
+export default function ArticleBannerImageField({
+  value,
+  onChange,
+  canManageMedia = false,
+  label,
+  placeholder,
+}) {
+  const fileInputRef = useRef(null);
+  const [media, setMedia] = useState([]);
+  const [isLoading, setIsLoading] = useState(false);
+  const [isUploading, setIsUploading] = useState(false);
+  const [error, setError] = useState('');
+
+  const setBannerUrl = (url) => {
+    onChange({
+      target: {
+        name: 'bannerImageUrl',
+        value: url,
+        type: 'text',
+      },
+    });
+  };
+
+  const loadMedia = async () => {
+    if (!canManageMedia) return;
+    setIsLoading(true);
+    setError('');
+
+    try {
+      const response = await mediaAPI.list({ usageType: 'article_banner', limit: 12 });
+      setMedia(response.media || []);
+    } catch (err) {
+      setError(err.message || 'Could not load media library.');
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    loadMedia();
+  }, [canManageMedia]);
+
+  const handleFileChange = async (event) => {
+    const file = event.target.files?.[0];
+    if (!file) return;
+
+    setIsUploading(true);
+    setError('');
+
+    try {
+      const response = await mediaAPI.uploadArticleImage(file, { usageType: 'article_banner' });
+      const nextUrl = response.media?.url;
+      if (nextUrl) {
+        setBannerUrl(nextUrl);
+        setMedia((current) => [response.media, ...current.filter((item) => item.id !== response.media.id)].slice(0, 12));
+      }
+    } catch (err) {
+      setError(err.message || 'Could not upload image.');
+    } finally {
+      setIsUploading(false);
+      if (fileInputRef.current) {
+        fileInputRef.current.value = '';
+      }
+    }
+  };
+
+  return (
+    <div className="space-y-3">
+      <FormInput
+        name="bannerImageUrl"
+        label={label}
+        value={value}
+        onChange={onChange}
+        placeholder={placeholder}
+      />
+
+      {value && (
+        <div className="overflow-hidden rounded border border-gray-200 bg-gray-50">
+          <img
+            src={value}
+            alt="Article banner preview"
+            className="h-40 w-full object-cover"
+          />
+        </div>
+      )}
+
+      {canManageMedia && (
+        <div className="rounded-md border border-gray-200 bg-gray-50 p-3">
+          <div className="flex flex-wrap items-center gap-2">
+            <button
+              type="button"
+              onClick={() => fileInputRef.current?.click()}
+              disabled={isUploading}
+              className="rounded border border-gray-300 bg-white px-3 py-1.5 text-sm font-medium text-gray-700 hover:bg-gray-100 disabled:opacity-50"
+            >
+              {isUploading ? 'Uploading...' : 'Upload photo'}
+            </button>
+            <button
+              type="button"
+              onClick={loadMedia}
+              disabled={isLoading}
+              className="rounded border border-gray-300 bg-white px-3 py-1.5 text-sm font-medium text-gray-700 hover:bg-gray-100 disabled:opacity-50"
+            >
+              {isLoading ? 'Loading...' : 'Refresh library'}
+            </button>
+          </div>
+
+          <input
+            ref={fileInputRef}
+            type="file"
+            accept="image/jpeg,image/png,image/webp"
+            className="hidden"
+            onChange={handleFileChange}
+          />
+
+          {error && <AlertMessage className="mt-3" message={error} />}
+
+          {media.length > 0 && (
+            <div className="mt-3 grid grid-cols-3 gap-2 sm:grid-cols-4 md:grid-cols-6">
+              {media.map((item) => (
+                <button
+                  key={item.id || item.url}
+                  type="button"
+                  onClick={() => setBannerUrl(item.url)}
+                  className={`overflow-hidden rounded border bg-white ${value === item.url ? 'border-blue-500 ring-2 ring-blue-200' : 'border-gray-200 hover:border-gray-300'}`}
+                  title={item.altText || item.originalName || 'Use image'}
+                >
+                  <img
+                    src={item.url}
+                    alt={item.altText || item.originalName || 'Media library image'}
+                    className="h-16 w-full object-cover"
+                  />
+                </button>
+              ))}
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/components/articles/ArticleBannerImageField.js
+++ b/components/articles/ArticleBannerImageField.js
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import FormInput from '@/components/ui/FormInput';
 import AlertMessage from '@/components/ui/AlertMessage';
 import { mediaAPI } from '@/lib/api';
@@ -28,7 +28,7 @@ export default function ArticleBannerImageField({
     });
   };
 
-  const loadMedia = async () => {
+  const loadMedia = useCallback(async () => {
     if (!canManageMedia) return;
     setIsLoading(true);
     setError('');
@@ -41,11 +41,11 @@ export default function ArticleBannerImageField({
     } finally {
       setIsLoading(false);
     }
-  };
+  }, [canManageMedia]);
 
   useEffect(() => {
     loadMedia();
-  }, [canManageMedia]);
+  }, [loadMedia]);
 
   const handleFileChange = async (event) => {
     const file = event.target.files?.[0];

--- a/components/articles/ArticleForm.js
+++ b/components/articles/ArticleForm.js
@@ -10,6 +10,7 @@ import FormSelect from '@/components/ui/FormSelect';
 import CascadingLocationSelector from '@/components/ui/CascadingLocationSelector';
 import TagInput from '@/components/ui/TagInput';
 import VideoEmbedField from '@/components/articles/VideoEmbedField';
+import ArticleBannerImageField from '@/components/articles/ArticleBannerImageField';
 import { locationAPI, tagAPI } from '@/lib/api';
 import articleCategories from '@/config/articleCategories.json';
 import { isCategoryRequired } from '@/lib/utils/articleTypes';
@@ -30,6 +31,7 @@ export default function ArticleForm({
   const { user } = useAuth();
   const [deleteConfirmOpen, setDeleteConfirmOpen] = useState(false);
   const isAdminOrModerator = user?.role === 'admin' || user?.role === 'moderator';
+  const canManageArticleMedia = ['admin', 'moderator', 'editor'].includes(user?.role);
   const contentInputRef = useRef(null);
   const [contentSelection, setContentSelection] = useState({ start: 0, end: 0 });
   const [tagSuggestions, setTagSuggestions] = useState([]);
@@ -495,12 +497,12 @@ export default function ArticleForm({
       />
  
       {!formData.sourceUrl && (
-        <FormInput
-          name="bannerImageUrl"
-            label={tArticles('form_banner_url_label')}
+        <ArticleBannerImageField
           value={formData.bannerImageUrl}
           onChange={handleInputChange}
-            placeholder={tArticles('form_banner_url_placeholder')}
+          canManageMedia={canManageArticleMedia}
+          label={tArticles('form_banner_url_label')}
+          placeholder={tArticles('form_banner_url_placeholder')}
         />
       )}
 


### PR DESCRIPTION
## Summary
- Replace the article banner URL-only field with a reusable media picker that keeps writing to `bannerImageUrl`
- Show upload and shared-library controls to admin, moderator, and editor users
- Keep regular viewers on the existing URL-only path and add ArticleForm coverage for both states

## Notes
- Existing image URLs continue to work because the form still submits `bannerImageUrl`.
- The picker uses the modular `mediaAPI` backend added in the previous PR, so the storage adapter can move later without changing the form.

## Testing
- Attempted `npm.cmd test -- --runTestsByPath __tests__/article-form.test.js --runInBand`, but this checkout has no `node_modules`, so Jest was not available locally.