### PR TITLE
[codex] Fix profile politics user id source

### DIFF
--- a/components/profile/ProfilePoliticsSection.js
+++ b/components/profile/ProfilePoliticsSection.js
@@ -2,6 +2,7 @@
 
 import { useState, useEffect, useCallback } from 'react';
 import { organizationAPI, politicalAffiliationAPI } from '@/lib/api';
+import { useAuth } from '@/lib/auth-context';
 import { ENDORSEMENT_LABELS, formatPoliticalPosition } from '@/lib/utils/politicalParties';
 import ProfileManifestSection from '@/components/profile/ProfileManifestSection';
 
@@ -66,7 +67,8 @@ export default function ProfilePoliticsSection({
   onWithdraw,
   manifestLoading,
 }) {
-  const userId = profileData?.id;
+  const { user } = useAuth();
+  const userId = profileData?.id ?? user?.id;
 
   const [parties, setParties] = useState([]);
   const [affiliations, setAffiliations] = useState([]);


### PR DESCRIPTION
## Summary
- Uses the authenticated `user.id` from auth context when `profileData.id` is not present.
- Keeps the previous `profileData.id` path as a fallback for compatibility.

## Root Cause
`useProfileForm()` intentionally builds `profileData` without the user's `id`, while exposing the authenticated `user` separately. After #949, the politics section stopped spinning but fell into the "profile not available" fallback because it only checked `profileData.id`.

## Validation
- Local syntax sanity check on the edited component content: balanced `()`, `{}`, and `[]`.
- Verified `useProfileForm()` returns `user` separately from `profileData`.
- Full lint/build not run because this project is not locally checked out with installed dependencies in this environment.