### PR TITLE
[codex] Fix organization-backed profile politics loading

### DIFF
--- a/__tests__/api/organizations-client.test.js
+++ b/__tests__/api/organizations-client.test.js
@@ -28,6 +28,18 @@ describe('organizationAPI', () => {
     expect(apiRequest).toHaveBeenCalledWith('/api/organizations?page=2&type=company');
   });
 
+  it('exposes list data on legacy top-level fields', async () => {
+    const organizations = [{ id: 1, name: 'Party Org' }];
+    const pagination = { currentPage: 1, totalPages: 1 };
+    apiRequest.mockResolvedValue({ success: true, data: { organizations, pagination } });
+
+    const result = await organizationAPI.getAll({ type: 'party' });
+
+    expect(result.data.organizations).toBe(organizations);
+    expect(result.organizations).toBe(organizations);
+    expect(result.pagination).toBe(pagination);
+  });
+
   it('calls get by slug endpoint', async () => {
     await organizationAPI.getBySlug('open-civic-lab');
 

--- a/lib/api/organizations.js
+++ b/lib/api/organizations.js
@@ -2,7 +2,17 @@ import { apiRequest } from './client.js';
 import { buildQueryEndpoint } from '../utils/queryString.js';
 
 export const organizationAPI = {
-  getAll: async (params = {}) => apiRequest(buildQueryEndpoint('/api/organizations', params)),
+  getAll: async (params = {}) => {
+    const response = await apiRequest(buildQueryEndpoint('/api/organizations', params));
+    if (response?.data && !response.organizations) {
+      return {
+        ...response,
+        organizations: response.data.organizations,
+        pagination: response.data.pagination,
+      };
+    }
+    return response;
+  },
 
   getBySlug: async (slug) => apiRequest(`/api/organizations/${slug}`),
 


### PR DESCRIPTION
## What changed

- Normalizes `organizationAPI.getAll()` so callers can read organization lists from both the current API envelope (`data.organizations`) and the legacy top-level convenience field (`organizations`).
- Adds regression coverage for the compatibility shape used by profile/admin party selectors.

## Why

The profile politics flow now relies on party organizations rather than hardcoded party data. Some frontend callers still expected `res.organizations`, while the backend returns `success/data/organizations`. That mismatch can leave organization-backed party selectors empty or inconsistent.

## Impact

This keeps existing callers working while preserving the current API response envelope for newer code.

## Validation

- `node --check` passed locally for touched files.
- Jest could not be run in the local checkout because `node_modules` is missing and `jest` is not installed there.

Note: remote `main` already has a newer `ProfilePoliticsSection` than the local checkout, including the user-id fallback, so this PR intentionally leaves that file untouched and only adds the missing API-client compatibility fix on top of `main`.