### PR TITLE
[codex] Add political affiliation status choices

### DIFF
--- a/__tests__/profile-tabs-refactor.test.js
+++ b/__tests__/profile-tabs-refactor.test.js
@@ -3,7 +3,10 @@ const path = require('path');
 
 describe('Profile page tab refactor', () => {
   const profilePagePath = path.join(__dirname, '..', 'app', 'profile', 'page.js');
+  const publicProfilePagePath = path.join(__dirname, '..', 'app', 'users', '[username]', 'page.js');
   const profileHookPath = path.join(__dirname, '..', 'hooks', 'useProfileForm.js');
+  const profilePoliticsSectionPath = path.join(__dirname, '..', 'components', 'profile', 'ProfilePoliticsSection.js');
+  const politicalAffiliationStatusPath = path.join(__dirname, '..', 'lib', 'utils', 'politicalAffiliationStatus.js');
   const enMessagesPath = path.join(__dirname, '..', 'messages', 'en.json');
   const elMessagesPath = path.join(__dirname, '..', 'messages', 'el.json');
   const roMessagesPath = path.join(__dirname, '..', 'messages', 'ro.json');
@@ -35,6 +38,20 @@ describe('Profile page tab refactor', () => {
     expect(source).toContain('handleAvatarSourceChange');
     expect(source).toContain('handleAddProfession');
     expect(source).toContain('handleAddInterest');
+  });
+
+  it('supports explicit political affiliation status options in the profile flow', () => {
+    const hookSource = fs.readFileSync(profileHookPath, 'utf8');
+    const politicsSource = fs.readFileSync(profilePoliticsSectionPath, 'utf8');
+    const statusSource = fs.readFileSync(politicalAffiliationStatusPath, 'utf8');
+    const publicProfileSource = fs.readFileSync(publicProfilePagePath, 'utf8');
+
+    expect(hookSource).toContain('politicalAffiliationStatus');
+    expect(hookSource).toContain('politicalAffiliationOtherText');
+    expect(statusSource).toContain('PREFER_NOT_TO_SAY');
+    expect(politicsSource).toContain('formatPoliticalAffiliationStatus');
+    expect(publicProfileSource).toContain('politicalStatusLabel');
+    expect(publicProfileSource).toContain('showPoliticalAffiliations');
   });
 
   it('defines profile tab labels for supported locales', () => {

--- a/app/users/[username]/page.js
+++ b/app/users/[username]/page.js
@@ -18,6 +18,10 @@ import { useAuth } from '@/lib/auth-context';
 import FollowButton from '@/components/follow/FollowButton';
 import EndorsementPanel from '@/components/EndorsementPanel';
 import { getPartyById, formatPoliticalPosition } from '@/lib/utils/politicalParties';
+import {
+  POLITICAL_AFFILIATION_STATUS,
+  formatPoliticalAffiliationStatus,
+} from '@/lib/utils/politicalAffiliationStatus';
 import { getExpertiseTagLabel, resolveProfessionLabel } from '@/lib/utils/professionTaxonomy';
 import TwitchEmbed from '@/components/profile/TwitchEmbed';
 
@@ -358,6 +362,12 @@ export default function PublicUserProfilePage() {
   const displayName = user?.firstNameNative && user?.lastNameNative
     ? `${user.firstNameNative} ${user.lastNameNative}`
     : user?.firstNameNative || user?.lastNameNative || '';
+  const politicalStatusLabel = formatPoliticalAffiliationStatus(
+    user?.politicalAffiliationStatus,
+    user?.politicalAffiliationOtherText
+  );
+  const showPoliticalAffiliations = !user?.politicalAffiliationStatus ||
+    user.politicalAffiliationStatus === POLITICAL_AFFILIATION_STATUS.PARTY;
 
   return (
     <div className="bg-gray-50 min-h-screen py-8">
@@ -407,7 +417,11 @@ export default function PublicUserProfilePage() {
                         {user.role}
                       </Badge>
                     )}
-                    {user.politicalAffiliations && user.politicalAffiliations.length > 0
+                    {!showPoliticalAffiliations && politicalStatusLabel ? (
+                      <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium bg-gray-100 text-gray-700">
+                        {politicalStatusLabel}
+                      </span>
+                    ) : user.politicalAffiliations && user.politicalAffiliations.length > 0
                       ? user.politicalAffiliations.map((aff) => {
                           const org = aff.organization;
                           if (!org) return null;
@@ -437,8 +451,7 @@ export default function PublicUserProfilePage() {
                               {party.abbreviation}
                             </span>
                           ) : null;
-                        })()
-                    }
+                        })()}
                     <FollowButton
                       targetUserId={user.id}
                       onCountChange={() => setCountsKey((k) => k + 1)}

--- a/components/profile/ProfilePoliticsSection.js
+++ b/components/profile/ProfilePoliticsSection.js
@@ -250,7 +250,16 @@ export default function ProfilePoliticsSection({
               <p className="rounded-md border border-red-100 bg-red-50 px-3 py-2 text-xs text-red-700">{mutationError}</p>
             )}
 
-            {affiliations.length > 0 ? (
+            {explicitNonPartyStatus ? (
+              <div className="rounded-lg border border-gray-200 bg-gray-50 p-4">
+                <p className="text-sm font-medium text-gray-900">
+                  {formatPoliticalAffiliationStatus(politicalStatus, profileData?.politicalAffiliationOtherText)}
+                </p>
+                <p className="mt-1 text-sm text-gray-500">
+                  Αυτή η επιλογή θα εμφανίζεται στο δημόσιο προφίλ αντί για κομματικές σχέσεις.
+                </p>
+              </div>
+            ) : showPartyAffiliations && affiliations.length > 0 ? (
               <ul className="space-y-3">
                 {affiliations.map((aff) => {
                   const org = aff.organization;
@@ -300,56 +309,67 @@ export default function ProfilePoliticsSection({
                   );
                 })}
               </ul>
-            ) : (
+            ) : showPartyAffiliations ? (
               <div className="rounded-lg border border-dashed border-gray-300 bg-gray-50 p-4">
                 <p className="text-sm font-medium text-gray-800">Δεν έχεις προσθέσει πολιτική τοποθέτηση.</p>
                 <p className="mt-1 text-sm text-gray-500">
                   Μπορείς να αφήσεις την ενότητα κενή ή να επιλέξεις μόνο σχέσεις που θέλεις να δηλώσεις δημόσια.
                 </p>
               </div>
+            ) : (
+              <div className="rounded-lg border border-dashed border-gray-300 bg-gray-50 p-4">
+                <p className="text-sm font-medium text-gray-800">Δεν έχεις επιλέξει δημόσια πολιτική τοποθέτηση.</p>
+                <p className="mt-1 text-sm text-gray-500">
+                  Επίλεξε αν θέλεις να δηλώσεις ότι είσαι ανεξάρτητος, ότι δεν απαντάς, κάτι άλλο ή σχέση με πολιτικό οργανισμό.
+                </p>
+              </div>
             )}
 
-            {availableParties.length > 0 ? (
-              <div className="space-y-3 border-t border-gray-100 pt-4">
-                <p className="text-sm font-medium text-gray-800">Προσθήκη σχέσης</p>
-                <div className="grid gap-2 sm:grid-cols-[minmax(0,1fr)_auto_auto]">
-                  <select
-                    value={selectedOrgId}
-                    onChange={(e) => setSelectedOrgId(e.target.value)}
-                    className="rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
-                    aria-label="Επιλογή κόμματος"
-                  >
-                    <option value="">Επιλογή κόμματος...</option>
-                    {availableParties.map((p) => (
-                      <option key={p.id} value={p.id}>
-                        {p.name}
-                        {p.politicalPosition ? ` (${formatPoliticalPosition(p.politicalPosition)})` : ''}
-                      </option>
-                    ))}
-                  </select>
-                  <select
-                    value={selectedLevel}
-                    onChange={(e) => setSelectedLevel(e.target.value)}
-                    className="rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
-                    aria-label="Τύπος σχέσης"
-                  >
-                    {ENDORSEMENT_OPTIONS.map((opt) => (
-                      <option key={opt.value} value={opt.value}>{opt.label}</option>
-                    ))}
-                  </select>
-                  <button
-                    type="button"
-                    onClick={handleAdd}
-                    disabled={!selectedOrgId || adding}
-                    className="rounded-md bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700 disabled:cursor-not-allowed disabled:opacity-50 transition-colors"
-                  >
-                    {adding ? 'Προσθήκη...' : 'Προσθήκη'}
-                  </button>
-                </div>
-                {addError && <p className="text-xs text-red-600">{addError}</p>}
-              </div>
-            ) : (
-              <p className="border-t border-gray-100 pt-4 text-sm text-gray-500">Δεν υπάρχουν άλλα διαθέσιμα κόμματα για προσθήκη.</p>
+            {showPartyAffiliations && (
+              <>
+                {availableParties.length > 0 ? (
+                  <div className="space-y-3 border-t border-gray-100 pt-4">
+                    <p className="text-sm font-medium text-gray-800">Προσθήκη σχέσης</p>
+                    <div className="grid gap-2 sm:grid-cols-[minmax(0,1fr)_auto_auto]">
+                      <select
+                        value={selectedOrgId}
+                        onChange={(e) => setSelectedOrgId(e.target.value)}
+                        className="rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+                        aria-label="Επιλογή κόμματος"
+                      >
+                        <option value="">Επιλογή κόμματος...</option>
+                        {availableParties.map((p) => (
+                          <option key={p.id} value={p.id}>
+                            {p.name}
+                            {p.politicalPosition ? ` (${formatPoliticalPosition(p.politicalPosition)})` : ''}
+                          </option>
+                        ))}
+                      </select>
+                      <select
+                        value={selectedLevel}
+                        onChange={(e) => setSelectedLevel(e.target.value)}
+                        className="rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+                        aria-label="Τύπος σχέσης"
+                      >
+                        {ENDORSEMENT_OPTIONS.map((opt) => (
+                          <option key={opt.value} value={opt.value}>{opt.label}</option>
+                        ))}
+                      </select>
+                      <button
+                        type="button"
+                        onClick={handleAdd}
+                        disabled={!selectedOrgId || adding}
+                        className="rounded-md bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700 disabled:cursor-not-allowed disabled:opacity-50 transition-colors"
+                      >
+                        {adding ? 'Προσθήκη...' : 'Προσθήκη'}
+                      </button>
+                    </div>
+                    {addError && <p className="text-xs text-red-600">{addError}</p>}
+                  </div>
+                ) : (
+                  <p className="border-t border-gray-100 pt-4 text-sm text-gray-500">Δεν υπάρχουν άλλα διαθέσιμα κόμματα για προσθήκη.</p>
+                )}
+              </>
             )}
           </div>
         )}


### PR DESCRIPTION
## Summary

Adds explicit political affiliation status handling in the profile UI so users can choose party/organization affiliation, unaffiliated, prefer not to say, or other.

## Why

The political profile section was still centered on party affiliations. These choices let a user publish a political position without forcing it into an organization/party relationship.

## Changes

- Shows the new status selector in the profile politics section and hides party relationship controls unless the party/organization option is selected.
- Displays non-party political status as a public profile badge.
- Adds a regression assertion for the profile flow wiring.

## Validation

- `node --check src\models\User.js`
- `node --check src\services\userService.js`
- `node --check src\migrations\20260627000000-add-political-affiliation-status-to-users.js`
- `npm.cmd test -- --runTestsByPath __tests__\profile-tabs-refactor.test.js`