### PR TITLE
Test deploy workflow with base64 SSH key

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -25,3 +25,4 @@ cd /var/www/Appofa && ./scripts/deploy.sh
 ```
 
 Smoke test note: merging a docs-only PR should still trigger the automatic deploy workflow on `main`.
+Smoke test note: `VPS_SSH_KEY_B64` can be used to avoid multiline private-key paste issues.


### PR DESCRIPTION
## Summary

- Adds a docs-only smoke-test note for `VPS_SSH_KEY_B64`.
- This PR is intended to trigger the production deploy workflow when merged.

## Test plan

- Merge this PR.
- Check **Actions > Deploy**.
- Expected: `Prepare SSH` and `Test SSH connection` pass, then `Run deploy script` runs on the VPS.