### PR TITLE
Add independent officials direct democracy hub

### DIFF
--- a/__tests__/persons.test.js
+++ b/__tests__/persons.test.js
@@ -1,5 +1,14 @@
 const request = require('supertest');
-const { sequelize, User, PublicPersonProfile, Location, LocationLink } = require('../src/models');
+const {
+  sequelize,
+  User,
+  PublicPersonProfile,
+  Location,
+  LocationLink,
+  LocationRole,
+  Manifest,
+  ManifestAcceptance,
+} = require('../src/models');
 
 const express = require('express');
 const cors = require('cors');
@@ -161,6 +170,84 @@ describe('Person Profile Tests (POST /api/persons)', () => {
   });
 
   // ── POST /api/persons ────────────────────────────────────────────────────
+
+  describe('GET /api/persons - independent officials and manifest filters', () => {
+    let independentMayorId;
+    let partyMayorId;
+    let independentWithoutOfficeId;
+    let directManifestSlug;
+
+    beforeAll(async () => {
+      const directManifest = await Manifest.create({
+        slug: 'direct-democracy-test',
+        title: 'Direct Democracy Test Manifest',
+        description: 'Officials commit to follow majority decisions.',
+        articleUrl: '/manifest-supporters',
+        isActive: true,
+      });
+      directManifestSlug = directManifest.slug;
+
+      const createPerson = async (firstNameEn, lastNameEn) => {
+        const res = await request(app)
+          .post('/api/persons')
+          .set(csrfHeaders(adminUserId, adminToken))
+          .send({ firstNameEn, lastNameEn, locationId: locationAId });
+        expect(res.status).toBe(201);
+        return res.body.data.profile.id;
+      };
+
+      independentMayorId = await createPerson('Independent', 'Mayor');
+      partyMayorId = await createPerson('Party', 'Mayor');
+      independentWithoutOfficeId = await createPerson('Independent', 'Citizen');
+
+      await User.update(
+        { politicalAffiliationStatus: 'unaffiliated' },
+        { where: { id: [independentMayorId, independentWithoutOfficeId] } }
+      );
+      await User.update(
+        { politicalAffiliationStatus: 'party' },
+        { where: { id: partyMayorId } }
+      );
+
+      await LocationRole.bulkCreate([
+        { locationId: locationAId, roleKey: 'mayor', userId: independentMayorId, sortOrder: 1, isActive: true },
+        { locationId: locationAId, roleKey: 'mayor', userId: partyMayorId, sortOrder: 2, isActive: true },
+      ]);
+
+      await ManifestAcceptance.create({
+        manifestId: directManifest.id,
+        userId: independentMayorId,
+      });
+    });
+
+    it('returns only unaffiliated profiles when independentOnly is set', async () => {
+      const res = await request(app).get('/api/persons?independentOnly=true&limit=100');
+      expect(res.status).toBe(200);
+      const ids = res.body.data.profiles.map((p) => p.id);
+      expect(ids).toContain(independentMayorId);
+      expect(ids).toContain(independentWithoutOfficeId);
+      expect(ids).not.toContain(partyMayorId);
+    });
+
+    it('returns only assigned public office holders when officialOnly is set', async () => {
+      const res = await request(app).get('/api/persons?officialOnly=true&limit=100');
+      expect(res.status).toBe(200);
+      const ids = res.body.data.profiles.map((p) => p.id);
+      expect(ids).toContain(independentMayorId);
+      expect(ids).toContain(partyMayorId);
+      expect(ids).not.toContain(independentWithoutOfficeId);
+      expect(res.body.data.profiles.find((p) => p.id === independentMayorId).locationRoles.length).toBeGreaterThan(0);
+    });
+
+    it('combines independent, office role and direct-democracy manifest filters', async () => {
+      const res = await request(app)
+        .get(`/api/persons?independentOnly=true&officialOnly=true&roleKey=mayor&manifestSlug=${directManifestSlug}&limit=100`);
+      expect(res.status).toBe(200);
+      const ids = res.body.data.profiles.map((p) => p.id);
+      expect(ids).toEqual([independentMayorId]);
+      expect(res.body.data.profiles[0].manifestAcceptances[0].manifest.slug).toBe(directManifestSlug);
+    });
+  });
 
   describe('POST /api/persons', () => {
     it('rejects unauthenticated requests', async () => {

--- a/app/independents/page.js
+++ b/app/independents/page.js
@@ -1,0 +1,355 @@
+'use client';
+
+import { useEffect, useMemo, useState } from 'react';
+import Link from 'next/link';
+import {
+  ArrowRightIcon,
+  CheckBadgeIcon,
+  ClipboardDocumentCheckIcon,
+  FunnelIcon,
+  MapPinIcon,
+  ScaleIcon,
+  UserCircleIcon,
+} from '@heroicons/react/24/outline';
+import { personAPI, manifestAPI } from '@/lib/api';
+import { useAsyncData } from '@/hooks/useAsyncData';
+import LocationFilterBreadcrumb from '@/components/ui/LocationFilterBreadcrumb';
+import SearchInput from '@/components/ui/SearchInput';
+import SkeletonLoader from '@/components/ui/SkeletonLoader';
+import EmptyState from '@/components/ui/EmptyState';
+import Pagination from '@/components/ui/Pagination';
+import Badge from '@/components/ui/Badge';
+import locationRolesConfig from '@/config/locationRoles.json';
+
+const PAGE_SIZE = 12;
+const DIRECT_DEMOCRACY_HINTS = ['direct', 'democracy', 'democratic', 'dimokrat', 'δημοκρα'];
+
+function getDisplayName(profile) {
+  const nativeName = `${profile.firstNameNative || ''} ${profile.lastNameNative || ''}`.trim();
+  const englishName = `${profile.firstNameEn || ''} ${profile.lastNameEn || ''}`.trim();
+  return nativeName || englishName || profile.nickname || profile.username || 'Independent official';
+}
+
+function getRoleOptions() {
+  return Object.entries(locationRolesConfig.roles || {}).flatMap(([locationType, roles]) =>
+    roles.map((role) => ({
+      value: role.key,
+      label: role.titleEn || role.title || role.key,
+      locationType,
+    }))
+  );
+}
+
+function pickDirectDemocracyManifest(manifests) {
+  return manifests.find((manifest) => {
+    const text = `${manifest.slug || ''} ${manifest.title || ''} ${manifest.description || ''}`.toLowerCase();
+    return DIRECT_DEMOCRACY_HINTS.some((hint) => text.includes(hint));
+  }) || manifests[0] || null;
+}
+
+function OfficeList({ roles = [] }) {
+  const activeRoles = roles.filter((role) => role?.isActive !== false);
+  if (activeRoles.length === 0) return null;
+
+  return (
+    <div className="mt-4 space-y-2">
+      {activeRoles.slice(0, 3).map((role) => (
+        <div key={role.id} className="flex items-start gap-2 text-sm text-gray-600">
+          <ScaleIcon className="mt-0.5 h-4 w-4 flex-shrink-0 text-blue-600" />
+          <div>
+            <p className="font-medium text-gray-800">{role.roleKey?.replaceAll('_', ' ')}</p>
+            {role.location?.name && (
+              <p className="text-xs text-gray-500">{role.location.name}</p>
+            )}
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function ManifestCommitment({ acceptances = [], selectedManifestSlug }) {
+  const accepted = acceptances
+    .filter((acceptance) => acceptance?.manifest)
+    .filter((acceptance) => !selectedManifestSlug || acceptance.manifest.slug === selectedManifestSlug);
+
+  if (accepted.length === 0) {
+    return (
+      <Badge variant="default" icon={<ClipboardDocumentCheckIcon />}>
+        No direct-democracy pledge shown
+      </Badge>
+    );
+  }
+
+  return (
+    <Badge variant="success" icon={<ClipboardDocumentCheckIcon />}>
+      Majority-rule manifest accepted
+    </Badge>
+  );
+}
+
+function IndependentCard({ profile, selectedManifestSlug }) {
+  const name = getDisplayName(profile);
+  const photo = profile.photo || profile.avatar;
+  const href = profile.slug ? `/persons/${profile.slug}` : '/users';
+  const locationName = profile.homeLocation?.name || profile.constituency?.name || profile.location?.name;
+
+  return (
+    <Link
+      href={href}
+      className="group flex h-full flex-col rounded-lg border border-gray-200 bg-white p-5 shadow-sm transition hover:-translate-y-0.5 hover:border-blue-300 hover:shadow-md focus:outline-none focus:ring-2 focus:ring-blue-500"
+    >
+      <div className="flex items-start gap-4">
+        {photo ? (
+          <img
+            src={photo}
+            alt={name}
+            className="h-16 w-16 flex-shrink-0 rounded-full border border-gray-100 object-cover"
+          />
+        ) : (
+          <UserCircleIcon className="h-16 w-16 flex-shrink-0 text-gray-300" />
+        )}
+        <div className="min-w-0 flex-1">
+          <div className="flex flex-wrap items-center gap-2">
+            <h2 className="truncate text-base font-bold text-gray-900 group-hover:text-blue-700">
+              {name}
+            </h2>
+            {profile.claimStatus === 'claimed' && (
+              <CheckBadgeIcon className="h-5 w-5 text-green-600" aria-label="Verified profile" />
+            )}
+          </div>
+          {locationName && (
+            <p className="mt-1 flex items-center gap-1 text-sm text-gray-500">
+              <MapPinIcon className="h-4 w-4 flex-shrink-0" />
+              <span className="truncate">{locationName}</span>
+            </p>
+          )}
+          <div className="mt-3 flex flex-wrap gap-2">
+            <Badge variant="primary">Independent</Badge>
+            <ManifestCommitment
+              acceptances={profile.manifestAcceptances || []}
+              selectedManifestSlug={selectedManifestSlug}
+            />
+          </div>
+        </div>
+      </div>
+
+      <OfficeList roles={profile.locationRoles || []} />
+
+      {profile.bio && (
+        <p className="mt-4 line-clamp-3 text-sm leading-6 text-gray-600">{profile.bio}</p>
+      )}
+
+      <span className="mt-auto inline-flex items-center gap-1 pt-4 text-sm font-semibold text-blue-700">
+        View public profile
+        <ArrowRightIcon className="h-4 w-4 transition-transform group-hover:translate-x-0.5" />
+      </span>
+    </Link>
+  );
+}
+
+export default function IndependentsPage() {
+  const [page, setPage] = useState(1);
+  const [search, setSearch] = useState('');
+  const [locationId, setLocationId] = useState('');
+  const [roleKey, setRoleKey] = useState('');
+  const [committedOnly, setCommittedOnly] = useState(false);
+  const [selectedManifestSlug, setSelectedManifestSlug] = useState('');
+
+  const roleOptions = useMemo(() => getRoleOptions(), []);
+
+  const { data: manifests } = useAsyncData(
+    async () => {
+      const res = await manifestAPI.getAll();
+      return res?.success ? res.data?.manifests || [] : [];
+    },
+    [],
+    { initialData: [] }
+  );
+
+  useEffect(() => {
+    if (selectedManifestSlug || manifests.length === 0) return;
+    const directManifest = pickDirectDemocracyManifest(manifests);
+    if (directManifest?.slug) {
+      setSelectedManifestSlug(directManifest.slug);
+    }
+  }, [manifests, selectedManifestSlug]);
+
+  useEffect(() => {
+    setPage(1);
+  }, [search, locationId, roleKey, committedOnly, selectedManifestSlug]);
+
+  const queryParams = useMemo(() => {
+    const params = {
+      page,
+      limit: PAGE_SIZE,
+      independentOnly: 'true',
+      officialOnly: 'true',
+    };
+    if (search.trim()) params.search = search.trim();
+    if (locationId) params.locationId = locationId;
+    if (roleKey) params.roleKey = roleKey;
+    if (committedOnly) {
+      if (selectedManifestSlug) params.manifestSlug = selectedManifestSlug;
+      else params.hasManifestAcceptance = 'true';
+    }
+    return params;
+  }, [page, search, locationId, roleKey, committedOnly, selectedManifestSlug]);
+
+  const { data, loading, error } = useAsyncData(
+    async () => {
+      const res = await personAPI.getAll(queryParams);
+      return res?.success ? res.data : { profiles: [], pagination: { totalPages: 1 } };
+    },
+    [queryParams],
+    { initialData: { profiles: [], pagination: { totalPages: 1 } } }
+  );
+
+  const profiles = data?.profiles || [];
+  const pagination = data?.pagination || { currentPage: page, totalPages: 1 };
+  const selectedManifest = manifests.find((manifest) => manifest.slug === selectedManifestSlug);
+
+  return (
+    <div className="min-h-screen bg-gray-50">
+      <section className="border-b border-gray-200 bg-white">
+        <div className="app-container py-10">
+          <div className="max-w-4xl">
+            <p className="text-xs font-semibold uppercase tracking-wide text-blue-700">
+              Independent public officials
+            </p>
+            <h1 className="mt-2 text-3xl font-bold tracking-tight text-gray-900 md:text-4xl">
+              Organize officials around the majority mandate
+            </h1>
+            <p className="mt-4 max-w-3xl text-base leading-7 text-gray-600">
+              Find independent parliamentarians, mayors and civic office holders, then identify who has
+              accepted the direct-democracy manifest: the stronger promise to act according to the public majority.
+            </p>
+            <div className="mt-5 flex flex-wrap gap-3">
+              <Link
+                href="/polls"
+                className="inline-flex items-center gap-2 rounded-lg bg-blue-600 px-4 py-2 text-sm font-semibold text-white hover:bg-blue-700"
+              >
+                See majority polls
+                <ArrowRightIcon className="h-4 w-4" />
+              </Link>
+              <Link
+                href="/manifest-supporters"
+                className="inline-flex items-center gap-2 rounded-lg border border-gray-300 bg-white px-4 py-2 text-sm font-semibold text-gray-700 hover:bg-gray-50"
+              >
+                View manifest supporters
+              </Link>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <div className="app-container py-8">
+        <div className="mb-6 rounded-lg border border-gray-200 bg-white p-4 shadow-sm">
+          <div className="mb-4 flex items-center gap-2 text-sm font-semibold text-gray-800">
+            <FunnelIcon className="h-5 w-5 text-blue-600" />
+            Filters
+          </div>
+          <LocationFilterBreadcrumb value={locationId} onChange={(id) => setLocationId(id || '')} />
+          <div className="grid gap-3 md:grid-cols-[1.5fr_1fr_1fr]">
+            <SearchInput
+              value={search}
+              onChange={(event) => setSearch(event.target.value)}
+              placeholder="Search by name"
+            />
+            <select
+              value={roleKey}
+              onChange={(event) => setRoleKey(event.target.value)}
+              className="rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500"
+            >
+              <option value="">All offices</option>
+              {roleOptions.map((role) => (
+                <option key={`${role.locationType}-${role.value}`} value={role.value}>
+                  {role.label}
+                </option>
+              ))}
+            </select>
+            <select
+              value={selectedManifestSlug}
+              onChange={(event) => setSelectedManifestSlug(event.target.value)}
+              className="rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500"
+            >
+              <option value="">Any active manifest</option>
+              {manifests.map((manifest) => (
+                <option key={manifest.slug} value={manifest.slug}>
+                  {manifest.title}
+                </option>
+              ))}
+            </select>
+          </div>
+          <label className="mt-4 flex items-start gap-3 rounded-lg border border-green-200 bg-green-50 px-3 py-3 text-sm text-green-900">
+            <input
+              type="checkbox"
+              checked={committedOnly}
+              onChange={(event) => setCommittedOnly(event.target.checked)}
+              className="mt-1 h-4 w-4 rounded border-green-300 text-green-600 focus:ring-green-500"
+            />
+            <span>
+              <span className="font-semibold">Show only direct-democracy committed officials.</span>
+              <span className="block text-green-800/80">
+                {selectedManifest
+                  ? `Uses accepted manifest: ${selectedManifest.title}.`
+                  : 'Uses any active manifest acceptance until a direct-democracy manifest is selected.'}
+              </span>
+            </span>
+          </label>
+        </div>
+
+        {loading && (
+          <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
+            <SkeletonLoader count={6} type="card" />
+          </div>
+        )}
+
+        {!loading && error && (
+          <EmptyState
+            type="error"
+            title="Could not load independent officials"
+            description={error}
+          />
+        )}
+
+        {!loading && !error && profiles.length === 0 && (
+          <EmptyState
+            type="empty"
+            title="No independent officials found"
+            description="Try removing a filter, or add public office role assignments to independent person profiles."
+          />
+        )}
+
+        {!loading && !error && profiles.length > 0 && (
+          <>
+            <div className="mb-4 flex items-center justify-between text-sm text-gray-600">
+              <p>
+                Showing {profiles.length} independent official{profiles.length === 1 ? '' : 's'}
+              </p>
+              <p>
+                Page {pagination.currentPage || page} of {pagination.totalPages || 1}
+              </p>
+            </div>
+            <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
+              {profiles.map((profile) => (
+                <IndependentCard
+                  key={profile.id}
+                  profile={profile}
+                  selectedManifestSlug={selectedManifestSlug}
+                />
+              ))}
+            </div>
+            <Pagination
+              currentPage={page}
+              totalPages={pagination.totalPages || 1}
+              onPageChange={setPage}
+              onPrevious={() => setPage((current) => Math.max(1, current - 1))}
+              onNext={() => setPage((current) => Math.min(pagination.totalPages || 1, current + 1))}
+            />
+          </>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/components/layout/TopNav.js
+++ b/components/layout/TopNav.js
@@ -166,6 +166,13 @@ export default function TopNav() {
           href: '/users',
           icon: <UsersIcon className="h-4 w-4" />,
           mobileIcon: <UsersIcon className="h-5 w-5" />
+        },
+        {
+          id: 'independents',
+          label: tNav('independents'),
+          href: '/independents',
+          icon: <FlagIcon className="h-4 w-4" />,
+          mobileIcon: <FlagIcon className="h-5 w-5" />
         }
       ]
     },

--- a/doc/REPOSITORY_MAP.md
+++ b/doc/REPOSITORY_MAP.md
@@ -33,7 +33,7 @@ This instruction is permanent and must never be removed.
 - [Services (15)](#services-15)
 - [Backend Utilities (selected)](#backend-utilities-selected)
 - [Middleware (9)](#middleware-9)
-- [Frontend Pages (141)](#frontend-pages-141)
+- [Frontend Pages (142)](#frontend-pages-142)
 - [Components (154)](#components-154)
 - [API Client Modules (30)](#api-client-modules-30)
 - [Hooks (7)](#hooks-7)
@@ -369,7 +369,7 @@ Appofa/
 ### Persons (`/api/persons`)
 | Method | Path | Auth | Description |
 |--------|------|------|-------------|
-| GET | / | opt | List persons (claimStatus IS NOT NULL users) |
+| GET | / | opt | List persons (claimStatus IS NOT NULL users; filters include `independentOnly`, `officialOnly`, `roleKey`, `manifestSlug`, `hasManifestAcceptance` for the independent-officials/direct-democracy hub) |
 | GET | /search | — | Search person profiles by name |
 | GET | /unified-search | — | Unified search: person profiles + real users merged |
 | GET | /claims | admin | List pending claims |
@@ -458,7 +458,7 @@ Appofa/
 | locationService.js | Location data management (hierarchy, entities split into regular users vs unclaimed person profiles) |
 | newsletterService.js | Newsletter subscriber lifecycle + authenticated user preference upsert by user email + CSV import/export + campaign drafting/templates-ready payloads, stronger audience filtering (status/locale/source/tags/date ranges), scheduling + due processing, test sends, batched delivery, and per-recipient send logging |
 | oauthService.js | OAuth integration (GitHub, Google) |
-| personService.js | Person profile management, claims, placeholders (unclaimed profile slugs derive from required English names) |
+| personService.js | Person profile management, claims, placeholders (unclaimed profile slugs derive from required English names), plus independent-official discovery filters using `politicalAffiliationStatus`, `LocationRoles`, and `ManifestAcceptances` |
 | pollService.js | Poll operations & calculations (including org-membership access enforcement for org-scoped private polls/results/voting) |
 | civicQuestionService.js | Civic question business logic: visibility/location-scoped access, fixed-choice voting (`agree|disagree|present`), results visibility rules |
 | organizationService.js | Organization slug generation + organization search helpers |
@@ -497,7 +497,7 @@ Appofa/
 
 ---
 
-## Frontend Pages (141)
+## Frontend Pages (142)
 
 > i18n note: core public pages (`/`, `/login`, `/articles`, `/news`, `/profile`, `/admin`, `/editor`, `/polls`, `/instructions`, `/rules`, `/mission`, `/contribute`, `/contact`) and shared nav/footer/article cards now use `useTranslations(...)`.
 
@@ -509,6 +509,7 @@ Appofa/
 | `/newsletter/unsubscribe` | Public tokenized newsletter unsubscribe confirmation page |
 | `/profile` | User profile with sticky 4-tab layout (`Profile`, `Location & Politics`, `Skills & Interests`, `Settings`); tab content is split into `app/profile/tabs/*` while form state/effects/handlers are centralized in `hooks/useProfileForm.js`; includes profile-completeness card, newsletter preference toggle, and `?verified=1` success toast handling |
 | `/users`, `/users/[username]` | Unified people directory with visibility enforcement (`profileVisibility`): guests see only `public` profiles, authenticated users see `registered+public`, and `hidden` profiles are excluded from discovery. Profile page access is now optional-auth and enforces the same model (owner/admin/moderator can still access hidden directly). Shared filter bar (search, home-location button via `LocationFilterBreadcrumb`, domain, expertise) remains across tabs; person cards are fully clickable; `/discover-people` and `/persons` list pages are retired (404). |
+| `/independents` | Independent public-officials hub: lists unaffiliated person profiles assigned to `LocationRoles`, filters by location/office/search, and can narrow to officials who accepted a selected direct-democracy manifest via `ManifestAcceptances`. |
 | `/users/[username]/followers`, `/users/[username]/following` | Social connections |
 | `/bookmarks` | Saved items |
 | `/my-votes`, `/my-polls`, `/my-news` | User content |

--- a/messages/el.json
+++ b/messages/el.json
@@ -14,6 +14,7 @@
     "locations": "Τοποθεσίες",
     "cameras": "Κάμερες",
     "users": "Χρήστες",
+    "independents": "Ανεξάρτητοι",
     "discover_people": "Ανακαλύψτε Πρόσωπα",
     "pages": "Σελίδες",
     "my_profile": "Το προφίλ μου",

--- a/messages/en.json
+++ b/messages/en.json
@@ -14,6 +14,7 @@
     "locations": "Locations",
     "cameras": "Cameras",
     "users": "Users",
+    "independents": "Independents",
     "discover_people": "Discover People",
     "pages": "Pages",
     "my_profile": "My profile",

--- a/messages/ro.json
+++ b/messages/ro.json
@@ -14,6 +14,7 @@
     "locations": "Locații",
     "cameras": "Camere",
     "users": "Utilizatori",
+    "independents": "Independenți",
     "discover_people": "Descoperă persoane",
     "pages": "Pagini",
     "my_profile": "Profilul meu",

--- a/src/controllers/personController.js
+++ b/src/controllers/personController.js
@@ -5,8 +5,36 @@ const personController = {
   // GET /api/persons
   getPersons: async (req, res) => {
     try {
-      const { page, limit, constituencyId, search, claimStatus, expertiseArea, locationId, domainId } = req.query;
-      const data = await personService.getPersons({ page, limit, constituencyId, search, claimStatus, expertiseArea, locationId, domainId });
+      const {
+        page,
+        limit,
+        constituencyId,
+        search,
+        claimStatus,
+        expertiseArea,
+        locationId,
+        domainId,
+        independentOnly,
+        officialOnly,
+        roleKey,
+        manifestSlug,
+        hasManifestAcceptance,
+      } = req.query;
+      const data = await personService.getPersons({
+        page,
+        limit,
+        constituencyId,
+        search,
+        claimStatus,
+        expertiseArea,
+        locationId,
+        domainId,
+        independentOnly,
+        officialOnly,
+        roleKey,
+        manifestSlug,
+        hasManifestAcceptance,
+      });
       return res.status(200).json({ success: true, data });
     } catch (error) {
       if (error.status) return res.status(error.status).json({ success: false, message: error.message });

--- a/src/models/index.js
+++ b/src/models/index.js
@@ -280,6 +280,7 @@ LocationSection.belongsTo(User, { foreignKey: 'updatedByUserId', as: 'updatedBy'
 LocationRole.belongsTo(Location, { foreignKey: 'locationId', as: 'location' });
 Location.hasMany(LocationRole, { foreignKey: 'locationId', as: 'roles' });
 LocationRole.belongsTo(User, { foreignKey: 'userId', as: 'user' });
+User.hasMany(LocationRole, { foreignKey: 'userId', as: 'locationRoles' });
 
 // UserLocationRole associations (platform moderator/role assignments via join table)
 UserLocationRole.belongsTo(User, { foreignKey: 'userId', as: 'user' });

--- a/src/services/personService.js
+++ b/src/services/personService.js
@@ -2,7 +2,21 @@
 
 const crypto = require('crypto');
 const { Op } = require('sequelize');
-const { User, Location, LocationLink, Endorsement, DreamTeamVote, LocationRole, GovernmentCurrentHolder, GovernmentPositionSuggestion, FormationPick, Organization, UserPoliticalAffiliation } = require('../models');
+const {
+  User,
+  Location,
+  LocationLink,
+  Endorsement,
+  DreamTeamVote,
+  LocationRole,
+  GovernmentCurrentHolder,
+  GovernmentPositionSuggestion,
+  FormationPick,
+  Organization,
+  UserPoliticalAffiliation,
+  Manifest,
+  ManifestAcceptance,
+} = require('../models');
 const dbConfig = require('../config/database');
 const { normalizeGreek, sanitizeForLike } = require('../utils/greekNormalize');
 const {
@@ -82,6 +96,48 @@ const PROFILE_INCLUDE = [
   },
 ];
 
+function buildProfileInclude({ roleKey, officialOnly, manifestSlug, hasManifestAcceptance } = {}) {
+  const include = PROFILE_INCLUDE.map((entry) => ({ ...entry }));
+
+  const roleWhere = { isActive: true };
+  if (roleKey && typeof roleKey === 'string' && roleKey.trim()) {
+    roleWhere.roleKey = roleKey.trim();
+  }
+
+  include.push({
+    model: LocationRole,
+    as: 'locationRoles',
+    required: Boolean(officialOnly || roleKey),
+    where: roleWhere,
+    attributes: ['id', 'locationId', 'roleKey', 'sortOrder', 'isActive'],
+    include: [
+      {
+        model: Location,
+        as: 'location',
+        attributes: ['id', 'name', 'slug', 'type', 'parent_id'],
+      },
+    ],
+  });
+
+  const manifestInclude = {
+    model: Manifest,
+    as: 'manifest',
+    attributes: ['id', 'slug', 'title', 'articleUrl'],
+    where: { isActive: true },
+    required: false,
+  };
+
+  include.push({
+    model: ManifestAcceptance,
+    as: 'manifestAcceptances',
+    required: Boolean(hasManifestAcceptance || manifestSlug),
+    attributes: ['id', 'manifestId', 'acceptedAt'],
+    include: [manifestInclude],
+  });
+
+  return include;
+}
+
 const SAFE_USER_ATTRS = [
   'id', 'username', 'firstNameNative', 'lastNameNative', 'firstNameEn', 'lastNameEn',
   'nickname', 'avatar', 'email', 'role', 'claimStatus', 'slug'
@@ -146,13 +202,30 @@ function buildNameSearchWhere(search) {
 
 // ─── Public read ─────────────────────────────────────────────────────────────
 
-async function getPersons({ page = 1, limit = 12, constituencyId, search, claimStatus, expertiseArea, locationId, domainId } = {}) {
+async function getPersons({
+  page = 1,
+  limit = 12,
+  constituencyId,
+  search,
+  claimStatus,
+  expertiseArea,
+  locationId,
+  domainId,
+  independentOnly,
+  officialOnly,
+  roleKey,
+  manifestSlug,
+  hasManifestAcceptance,
+} = {}) {
   const pageNum = Math.max(1, parseInt(page, 10) || 1);
   const limitNum = Math.min(100, Math.max(1, parseInt(limit, 10) || 12));
   const offset = (pageNum - 1) * limitNum;
 
   // Only public person profiles (claimStatus IS NOT NULL)
   const where = { claimStatus: { [Op.ne]: null } };
+  if (independentOnly === true || independentOnly === 'true' || independentOnly === '1') {
+    where.politicalAffiliationStatus = 'unaffiliated';
+  }
   if (constituencyId) where.constituencyId = parseInt(constituencyId, 10);
   if (locationId) {
     const parsedLocationId = parseInt(locationId, 10);
@@ -176,9 +249,62 @@ async function getPersons({ page = 1, limit = 12, constituencyId, search, claimS
     where.professions = { [likeOp]: `%"domainId":"${safeDomainId}"%` };
   }
 
+  const includeFilters = {
+    officialOnly: officialOnly === true || officialOnly === 'true' || officialOnly === '1',
+    roleKey,
+    hasManifestAcceptance: hasManifestAcceptance === true || hasManifestAcceptance === 'true' || hasManifestAcceptance === '1',
+    manifestSlug,
+  };
+
+  if (manifestSlug && typeof manifestSlug === 'string') {
+    const manifest = await Manifest.findOne({
+      where: { slug: manifestSlug, isActive: true },
+      attributes: ['id'],
+    });
+    if (!manifest) {
+      return {
+        profiles: [],
+        pagination: {
+          currentPage: pageNum,
+          totalPages: 0,
+          totalItems: 0,
+          itemsPerPage: limitNum,
+        },
+      };
+    }
+    includeFilters.hasManifestAcceptance = true;
+    includeFilters.manifestId = manifest.id;
+  } else if (includeFilters.hasManifestAcceptance) {
+    const activeManifests = await Manifest.findAll({
+      where: { isActive: true },
+      attributes: ['id'],
+    });
+    includeFilters.manifestIds = activeManifests.map((manifest) => manifest.id);
+    if (includeFilters.manifestIds.length === 0) {
+      return {
+        profiles: [],
+        pagination: {
+          currentPage: pageNum,
+          totalPages: 0,
+          totalItems: 0,
+          itemsPerPage: limitNum,
+        },
+      };
+    }
+  }
+
+  const include = buildProfileInclude(includeFilters);
+  const manifestAcceptanceInclude = include.find((item) => item.as === 'manifestAcceptances');
+  if (includeFilters.manifestId && manifestAcceptanceInclude) {
+    manifestAcceptanceInclude.where = { manifestId: includeFilters.manifestId };
+  } else if (includeFilters.manifestIds && manifestAcceptanceInclude) {
+    manifestAcceptanceInclude.where = { manifestId: { [Op.in]: includeFilters.manifestIds } };
+  }
+
   const { count, rows } = await User.findAndCountAll({
     where,
-    include: PROFILE_INCLUDE,
+    include,
+    distinct: true,
     limit: limitNum,
     offset,
     order: [['createdAt', 'DESC']]
@@ -198,7 +324,7 @@ async function getPersons({ page = 1, limit = 12, constituencyId, search, claimS
 async function getPersonBySlug(slug) {
   const profile = await User.findOne({
     where: { slug, claimStatus: { [Op.ne]: null } },
-    include: PROFILE_INCLUDE
+    include: buildProfileInclude()
   });
   if (!profile) throw new ServiceError(404, 'Person profile not found.');
   return profile;
@@ -206,7 +332,7 @@ async function getPersonBySlug(slug) {
 
 async function getPersonById(id) {
   const profile = await User.findByPk(id, {
-    include: PROFILE_INCLUDE
+    include: buildProfileInclude()
   });
   if (!profile || profile.claimStatus === null) throw new ServiceError(404, 'Person profile not found.');
   return profile;


### PR DESCRIPTION
## Summary
- Add an `/independents` hub for independent parliamentaries, mayors, and officials aligned with direct democracy commitments.
- Add person discovery filters for independent status, official roles, role keys, and manifest acceptance.
- Wire navigation/i18n and expand person API coverage plus repository map docs.

## Verification
- `npx.cmd jest __tests__/persons.test.js --runInBand`
- `npx.cmd jest __tests__/top-nav-grouped-menu.test.js --runInBand`
- `npm.cmd run frontend:build`
- `npm.cmd run lint`