### PR TITLE
[codex] Improve admin sidebar navigation

### DIFF
--- a/__tests__/AdminSidebar.test.js
+++ b/__tests__/AdminSidebar.test.js
@@ -1,0 +1,78 @@
+/** @jest-environment <rootDir>/jest-jsdom-env.js */
+
+const React = require('react');
+const { act } = require('react');
+const { createRoot } = require('react-dom/client');
+const { useAuth } = require('@/lib/auth-context');
+const { usePathname } = require('next/navigation');
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+jest.mock('next/link', () => {
+  const React = require('react');
+  return {
+    __esModule: true,
+    default: ({ href, children, ...props }) => React.createElement('a', { href, ...props }, children),
+  };
+});
+
+jest.mock('next/navigation', () => ({
+  usePathname: jest.fn(() => '/admin'),
+}));
+
+jest.mock('@/lib/auth-context', () => ({
+  useAuth: jest.fn(),
+}));
+
+const AdminSidebar = require('../components/admin/AdminSidebar').default;
+
+const renderSidebar = (user = { role: 'admin' }, pathname = '/admin') => {
+  useAuth.mockReturnValue({ user });
+  usePathname.mockReturnValue(pathname);
+
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  const root = createRoot(container);
+
+  act(() => {
+    root.render(React.createElement(AdminSidebar));
+  });
+
+  return { container, root };
+};
+
+afterEach(() => {
+  jest.clearAllMocks();
+  document.body.innerHTML = '';
+});
+
+describe('AdminSidebar', () => {
+  it('groups admin navigation into operational sections', () => {
+    const { container, root } = renderSidebar();
+
+    expect(container.textContent).toContain('Overview');
+    expect(container.textContent).toContain('People');
+    expect(container.textContent).toContain('Content');
+    expect(container.textContent).toContain('Moderation');
+    expect(container.textContent).toContain('Locations & Access');
+    expect(container.textContent).toContain('System');
+    expect(container.textContent).toContain('Geo & Countries');
+    expect(container.textContent).toContain('Organizations');
+    expect(container.querySelector('nav a[href="/admin"]')?.getAttribute('aria-current')).toBe('page');
+
+    act(() => root.unmount());
+  });
+
+  it('hides admin-only destinations for moderators', () => {
+    const { container, root } = renderSidebar({ role: 'moderator' });
+
+    expect(container.textContent).toContain('Reports');
+    expect(container.textContent).toContain('Locations');
+    expect(container.textContent).not.toContain('Geo & Countries');
+    expect(container.textContent).not.toContain('IP Rules');
+    expect(container.textContent).not.toContain('System Health');
+    expect(container.textContent).not.toContain('Worker Status');
+
+    act(() => root.unmount());
+  });
+});

--- a/components/admin/AdminSidebar.js
+++ b/components/admin/AdminSidebar.js
@@ -1,37 +1,87 @@
 'use client';
 
+import { useState } from 'react';
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
 import {
-  HomeIcon, MapPinIcon, EnvelopeIcon,
-  UserGroupIcon, UsersIcon, FlagIcon, StarIcon, PhotoIcon, HeartIcon,
-  Bars3Icon, XMarkIcon, DocumentTextIcon, ShieldExclamationIcon, GlobeEuropeAfricaIcon,
-  AdjustmentsHorizontalIcon
+  AdjustmentsHorizontalIcon,
+  Bars3Icon,
+  BuildingOfficeIcon,
+  DocumentTextIcon,
+  EnvelopeIcon,
+  FlagIcon,
+  GlobeEuropeAfricaIcon,
+  HeartIcon,
+  HomeIcon,
+  IdentificationIcon,
+  MapPinIcon,
+  PhotoIcon,
+  ShieldExclamationIcon,
+  StarIcon,
+  UserGroupIcon,
+  UserMinusIcon,
+  UsersIcon,
+  XMarkIcon,
 } from '@heroicons/react/24/outline';
-import { useState } from 'react';
+import { useAuth } from '@/lib/auth-context';
 
-const navItems = [
-  { href: '/admin', label: 'Dashboard', icon: HomeIcon },
-  { href: '/admin/homepage', label: 'Homepage', icon: AdjustmentsHorizontalIcon },
-  { href: '/admin/users', label: 'Users', icon: UsersIcon },
-  { href: '/admin/articles', label: 'Articles', icon: DocumentTextIcon },
-  { href: '/admin/locations', label: 'Locations', icon: MapPinIcon },
-  { href: '/admin/messages', label: 'Messages', icon: EnvelopeIcon },
-  { href: '/admin/newsletter', label: 'Newsletter', icon: EnvelopeIcon },
-  { href: '/admin/persons', label: 'Persons', icon: UserGroupIcon },
-  { href: '/admin/manifests', label: 'Manifests', icon: DocumentTextIcon },
-  { href: '/admin/reports', label: 'Reports', icon: FlagIcon },
-  { href: '/admin/dream-team', label: 'Dream Team', icon: StarIcon },
-  { href: '/admin/hero', label: 'Hero Settings', icon: PhotoIcon },
-  { href: '/admin/geo', label: '🌍 Γεωγραφικά & Χώρες', icon: GlobeEuropeAfricaIcon },
-  { href: '/admin/ip-rules', label: 'IP Rules', icon: ShieldExclamationIcon },
-  { href: '/admin/status', label: 'System Health', icon: HeartIcon },
-  { href: '/admin/worker-status', label: 'Worker Status', icon: HeartIcon },
+const navSections = [
+  {
+    label: 'Overview',
+    items: [
+      { href: '/admin', label: 'Dashboard', icon: HomeIcon },
+    ],
+  },
+  {
+    label: 'People',
+    items: [
+      { href: '/admin/users', label: 'Users', icon: UsersIcon },
+      { href: '/admin/persons', label: 'Persons', icon: UserGroupIcon },
+      { href: '/admin/persons/claims', label: 'Person Claims', icon: IdentificationIcon },
+      { href: '/admin/removal-requests', label: 'Removal Requests', icon: UserMinusIcon },
+      { href: '/admin/organizations', label: 'Organizations', icon: BuildingOfficeIcon },
+    ],
+  },
+  {
+    label: 'Content',
+    items: [
+      { href: '/admin/homepage', label: 'Homepage', icon: AdjustmentsHorizontalIcon },
+      { href: '/admin/hero', label: 'Hero Settings', icon: PhotoIcon },
+      { href: '/admin/articles', label: 'Articles', icon: DocumentTextIcon },
+      { href: '/admin/manifests', label: 'Manifests', icon: DocumentTextIcon },
+      { href: '/admin/dream-team', label: 'Dream Team', icon: StarIcon },
+    ],
+  },
+  {
+    label: 'Moderation',
+    items: [
+      { href: '/admin/reports', label: 'Reports', icon: FlagIcon },
+      { href: '/admin/messages', label: 'Messages', icon: EnvelopeIcon },
+      { href: '/admin/newsletter', label: 'Newsletter', icon: EnvelopeIcon },
+    ],
+  },
+  {
+    label: 'Locations & Access',
+    items: [
+      { href: '/admin/locations', label: 'Locations', icon: MapPinIcon },
+      { href: '/admin/geo', label: 'Geo & Countries', icon: GlobeEuropeAfricaIcon, adminOnly: true },
+      { href: '/admin/ip-rules', label: 'IP Rules', icon: ShieldExclamationIcon, adminOnly: true },
+    ],
+  },
+  {
+    label: 'System',
+    items: [
+      { href: '/admin/status', label: 'System Health', icon: HeartIcon, adminOnly: true },
+      { href: '/admin/worker-status', label: 'Worker Status', icon: HeartIcon, adminOnly: true },
+    ],
+  },
 ];
 
 export default function AdminSidebar() {
   const pathname = usePathname();
+  const { user } = useAuth();
   const [mobileOpen, setMobileOpen] = useState(false);
+  const isAdmin = user?.role === 'admin';
 
   const isActive = (href) => {
     if (href === '/admin') return pathname === '/admin';
@@ -39,23 +89,38 @@ export default function AdminSidebar() {
   };
 
   const navContent = (
-    <nav className="flex flex-col gap-1 p-3">
-      {navItems.map(item => {
-        const active = isActive(item.href);
+    <nav className="flex flex-col gap-4 p-3" aria-label="Admin navigation">
+      {navSections.map((section) => {
+        const visibleItems = section.items.filter((item) => !item.adminOnly || isAdmin);
+        if (visibleItems.length === 0) return null;
+
         return (
-          <Link
-            key={item.href}
-            href={item.href}
-            onClick={() => setMobileOpen(false)}
-            className={`flex items-center gap-3 px-3 py-2 rounded-lg text-sm font-medium transition-colors ${
-              active
-                ? 'bg-blue-50 text-blue-700'
-                : 'text-gray-600 hover:bg-gray-100 hover:text-gray-900'
-            }`}
-          >
-            <item.icon className={`h-5 w-5 flex-shrink-0 ${active ? 'text-blue-600' : 'text-gray-400'}`} />
-            <span>{item.label}</span>
-          </Link>
+          <div key={section.label}>
+            <div className="px-3 pb-1 text-[11px] font-semibold uppercase tracking-wide text-gray-400">
+              {section.label}
+            </div>
+            <div className="flex flex-col gap-1">
+              {visibleItems.map((item) => {
+                const active = isActive(item.href);
+                return (
+                  <Link
+                    key={item.href}
+                    href={item.href}
+                    onClick={() => setMobileOpen(false)}
+                    aria-current={active ? 'page' : undefined}
+                    className={`flex items-center gap-3 rounded-lg px-3 py-2 text-sm font-medium transition-colors ${
+                      active
+                        ? 'bg-blue-50 text-blue-700'
+                        : 'text-gray-600 hover:bg-gray-100 hover:text-gray-900'
+                    }`}
+                  >
+                    <item.icon className={`h-5 w-5 flex-shrink-0 ${active ? 'text-blue-600' : 'text-gray-400'}`} />
+                    <span className="truncate">{item.label}</span>
+                  </Link>
+                );
+              })}
+            </div>
+          </div>
         );
       })}
     </nav>
@@ -63,7 +128,6 @@ export default function AdminSidebar() {
 
   return (
     <>
-      {/* Mobile toggle button */}
       <div className="md:hidden fixed top-4 left-4 z-40">
         <button
           onClick={() => setMobileOpen(!mobileOpen)}
@@ -74,7 +138,6 @@ export default function AdminSidebar() {
         </button>
       </div>
 
-      {/* Mobile overlay */}
       {mobileOpen && (
         <div
           className="md:hidden fixed inset-0 bg-black/30 z-30"
@@ -82,17 +145,16 @@ export default function AdminSidebar() {
         />
       )}
 
-      {/* Sidebar - mobile: slide-in overlay, desktop: static */}
       <aside className={`
         fixed md:sticky top-0 left-0 z-30 h-screen
-        w-56 bg-white border-r border-gray-200
+        w-64 bg-white border-r border-gray-200
         transform transition-transform duration-200 ease-in-out
         ${mobileOpen ? 'translate-x-0' : '-translate-x-full md:translate-x-0'}
         overflow-y-auto
       `}>
         <div className="p-4 border-b border-gray-200">
           <Link href="/admin" className="text-lg font-bold text-gray-900" onClick={() => setMobileOpen(false)}>
-            ⚙️ Admin
+            Admin
           </Link>
         </div>
         {navContent}


### PR DESCRIPTION
## Summary

- Groups admin sidebar links into operational sections so the admin surface is easier to scan.
- Adds missing high-value admin destinations for organizations, person claims, and removal requests.
- Hides admin-only access/system destinations from moderator navigation.
- Removes the corrupted/emoji admin labels in the sidebar and adds an explicit active-page state.

## Validation

- `npm.cmd test -- --runTestsByPath __tests__\AdminSidebar.test.js --coverage=false`
- `npm.cmd test -- --runTestsByPath __tests__\frontend.test.js --coverage=false`
- `npm.cmd run frontend:build`

Note: this environment does not expose local `git` or `gh`, so the branch and PR were created through the GitHub connector after local tests passed.